### PR TITLE
Address PR review comments from GitHub Copilot

### DIFF
--- a/MyTowerRegistration.API/GraphQL/DataLoaders/UserDataLoader.cs
+++ b/MyTowerRegistration.API/GraphQL/DataLoaders/UserDataLoader.cs
@@ -83,7 +83,6 @@ public class UserBatchDataLoader : BatchDataLoader<int, User>
 
     protected override async Task<IReadOnlyDictionary<int, User>> LoadBatchAsync(IReadOnlyList<int> userIds, CancellationToken ct)
     {
-        IDictionary<int, User> users = await _repository.GetByIdsAsync(userIds, ct);
-        return (IReadOnlyDictionary<int, User>) users;
+        return await _repository.GetByIdsAsync(userIds, ct);
     }
 }

--- a/MyTowerRegistration.API/GraphQL/Types/UserErrorType.cs
+++ b/MyTowerRegistration.API/GraphQL/Types/UserErrorType.cs
@@ -11,14 +11,15 @@
 //   - Hot Chocolate provides this pattern out of the box with payload types
 //
 // The GraphQL schema will show:
-//   type UserError { message: String!, code: String! }
+//   type UserError { message: String!, code: UserErrorCode! }
+//   enum UserErrorCode { INVALID_EMAIL, USERNAME_TAKEN, EMAIL_TAKEN, ... }
 // =============================================================================
 
 namespace MyTowerRegistration.API.GraphQL.Types;
 
 // TODO 1: Create a C# record named UserError with two properties:
 //   - string Message
-//   - string Code
+//   - UserErrorCode Code   ← enum, not string; HC maps this to a GraphQL enum type
 //
 //   Use a record (not a class) because errors are immutable value objects.
 //   Records in C# are like TypeScript's `readonly` types + structural equality.

--- a/MyTowerRegistration.API/Program.cs
+++ b/MyTowerRegistration.API/Program.cs
@@ -50,7 +50,7 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 //   Compare to Node.js:
 //     const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 //   But here it's managed by DI — you never manually create/dispose connections.
-IServiceCollection serviceCollection = builder.Services.AddDbContext<AppDbContext>((DbContextOptionsBuilder options) => {
+builder.Services.AddDbContext<AppDbContext>((DbContextOptionsBuilder options) => {
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection"));
 });
 

--- a/MyTowerRegistration.Data/GlobalUsings.cs
+++ b/MyTowerRegistration.Data/GlobalUsings.cs
@@ -1,4 +1,4 @@
 // Global type aliases and common usings for the Data project
-global using UserByIdDictionary = System.Collections.Generic.IDictionary<int, MyTowerRegistration.Data.Models.User>;
+global using UserByIdDictionary = System.Collections.Generic.IReadOnlyDictionary<int, MyTowerRegistration.Data.Models.User>;
 global using MyTowerRegistration.Data.Models;
 global using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Fixed issues:
- UserErrorType.cs: fix comments to show UserErrorCode enum (not String) in schema docs
- GlobalUsings.cs: change UserByIdDictionary alias from IDictionary to IReadOnlyDictionary so return type is already correct for DataLoader without a cast
- UserDataLoader.cs: remove fragile explicit cast (IDictionary→IReadOnlyDictionary) now unnecessary since UserByIdDictionary is already IReadOnlyDictionary
- Program.cs: remove unused IServiceCollection local variable from AddDbContext call

Intentionally left unchanged (with reasoning documented):
- UserErrorCode remains an enum (not string) — provides compile-time type safety; Hot Chocolate maps C# enums to GraphQL Enum types automatically
- CancellationToken ct parameters remain non-default — preserves the full cancellation chain from HTTP request down to the database
- Async suffix on repository methods retained — standard .NET naming convention for Task-returning methods (IUserRepository, UserRepository)

All 10 tests still pass after these changes.

https://claude.ai/code/session_01DW1gdGCFnCei66edJpZBAB