### PR TITLE
Add GitHub MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}


### PR DESCRIPTION
Configures the official GitHub MCP server (hosted remote) so Claude Code can authenticate with GitHub and access PR review comments, issues, and other GitHub API data directly during sessions.

Authenticate with: /mcp → GitHub → OAuth flow

https://claude.ai/code/session_01DW1gdGCFnCei66edJpZBAB