### PR TITLE
Pass DataLoaderOptions directly to base, removing redundant null coal…

### DIFF
--- a/MyTowerRegistration.API/GraphQL/DataLoaders/UserDataLoader.cs
+++ b/MyTowerRegistration.API/GraphQL/DataLoaders/UserDataLoader.cs
@@ -53,7 +53,7 @@ public class UserBatchDataLoader : BatchDataLoader<int, User>
         IUserRepository repository, 
         IBatchScheduler batchScheduler, 
         DataLoaderOptions? options = null) 
-        : base(batchScheduler, options ?? new DataLoaderOptions())
+        : base(batchScheduler, options)
     {
         _repository = repository;
     }


### PR DESCRIPTION
…escing

HC's DataLoaderBase handles null options internally; ?? new DataLoaderOptions() was unnecessary and diverged from the TODO comment's intended signature.

https://claude.ai/code/session_01VQXjjwAgJM4gagYHVoNmh3