### PR TITLE
Fix Windows path conversion and require DB SSL

### DIFF
--- a/scripts/deploy-aws.sh
+++ b/scripts/deploy-aws.sh
@@ -367,6 +367,12 @@ echo "RDS ready: ${RDS_ENDPOINT}"
 echo ""
 echo "--- Step 8: Updating secret with full connection string ---"
 
+# Trust Server Certificate=true skips RDS CA chain validation. Traffic is still
+# encrypted in transit, but the server certificate isn't verified against a
+# trusted CA — meaning a MITM inside the VPC could theoretically intercept it.
+# This is acceptable for a first deployment; the proper fix is to ship the AWS
+# RDS CA bundle in the container image and switch to SSL Mode=VerifyFull.
+# See: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
 CONNECTION_STRING="Host=${RDS_ENDPOINT};Port=5432;Database=${DB_NAME};Username=${DB_USERNAME};Password=${DB_PASSWORD};SSL Mode=Require;Trust Server Certificate=true"
 
 # Use jq to build the JSON — direct string interpolation would break if the


### PR DESCRIPTION
In scripts/deploy-aws.sh: set MSYS_NO_PATHCONV=1 to prevent Git Bash on Windows from converting leading-slash arguments into Windows paths (e.g. /ecs/... -> C:/Program Files/Git/...). Also update the RDS connection string to include "SSL Mode=Require;Trust Server Certificate=true" so the secret update uses an encrypted connection and avoids certificate validation issues.