### PR TITLE
Add per-IP rate limiting to GraphQL endpoint

### DIFF
--- a/MyTowerRegistration.API/Program.cs
+++ b/MyTowerRegistration.API/Program.cs
@@ -20,7 +20,9 @@
 //   4. Run                                          — app.Run()
 // =============================================================================
 
+using System.Threading.RateLimiting;
 using HotChocolate.Execution;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
 using MyTowerRegistration.Data;
 using MyTowerRegistration.Data.Repositories;
@@ -142,6 +144,62 @@ builder.Services.AddCors(options =>
     });
 });
 
+// --- Rate Limiting ----------------------------------------------------------
+// ASP.NET Core's built-in rate limiter (System.Threading.RateLimiting, .NET 7+).
+// No NuGet package needed — it ships with the framework.
+//
+// WHY per-IP fixed-window:
+//   - There is no authentication yet, so IP address is the only available key.
+//   - Fixed window is the simplest policy to reason about: each window resets
+//     after WindowSeconds seconds. A sliding window would smooth bursts but
+//     is harder to explain and the difference is minor at these limits.
+//   - QueueLimit = 0: excess requests are rejected immediately (HTTP 429).
+//     Queuing makes sense for paid APIs where you'd rather wait than drop;
+//     for an open registration endpoint, queueing just delays abuse, not stops it.
+//
+// HOW partitioning works:
+//   RateLimitPartition.GetFixedWindowLimiter creates a separate counter per
+//   partition key (here: the client IP). Two different IPs each get their own
+//   independent PermitLimit budget. A single shared global counter would be
+//   exhausted by one heavy client and deny everyone else.
+//
+// CONFIG:
+//   RateLimiting:PermitLimit   — max requests per window (default 30)
+//   RateLimiting:WindowSeconds — window length in seconds (default 60)
+//   Override in ECS via env vars: RateLimiting__PermitLimit, RateLimiting__WindowSeconds
+int permitLimit   = builder.Configuration.GetValue<int>("RateLimiting:PermitLimit",  defaultValue: 30);
+int windowSeconds = builder.Configuration.GetValue<int>("RateLimiting:WindowSeconds", defaultValue: 60);
+
+builder.Services.AddRateLimiter(rateLimiterOptions =>
+{
+    rateLimiterOptions.AddPolicy("GraphQL", httpContext =>
+        RateLimitPartition.GetFixedWindowLimiter(
+            // LIMITATION: all requests that arrive with no RemoteIpAddress (can
+            // happen in tests and behind some proxies) fall into one shared
+            // "unknown" bucket — a single counter for every such client.
+            // Once an ALB or reverse proxy sits in front, the balancer's IP
+            // becomes every client's RemoteIpAddress and this bucket is
+            // exhausted for everyone at once.
+            // Fix: call app.UseForwardedHeaders() (or configure
+            // ForwardedHeadersOptions) before UseRateLimiter so the
+            // X-Forwarded-For header is unwrapped into RemoteIpAddress
+            // before the limiter reads it.
+            partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit            = permitLimit,
+                Window                 = TimeSpan.FromSeconds(windowSeconds),
+                QueueProcessingOrder   = QueueProcessingOrder.OldestFirst,
+                QueueLimit             = 0,
+            }
+        )
+    );
+
+    // 429 Too Many Requests is the standard HTTP status for rate limit violations.
+    // The default would be 503 Service Unavailable, which misrepresents the cause.
+    rateLimiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
+
 // Keep OpenAPI support from the template
 builder.Services.AddOpenApi();
 
@@ -229,6 +287,26 @@ if (app.Environment.IsDevelopment())
 // OPTIONS request before the real POST — UseCors handles that response.
 app.UseCors("AdminPolicy");
 
-app.MapGraphQL("/api/graphql");
+// UseRateLimiter must come AFTER UseCors so that CORS preflight OPTIONS
+// responses are sent correctly before the rate limiter has a chance to reject
+// the request. It must come BEFORE MapGraphQL so the limiter runs on every
+// inbound GraphQL operation.
+app.UseRateLimiter();
+
+app.MapGraphQL("/api/graphql").RequireRateLimiting("GraphQL");
 
 app.Run();
+
+// =============================================================================
+// TEST HOOK — WebApplicationFactory visibility
+// =============================================================================
+//
+// Top-level statements in .NET 6+ generate an *internal* implicit Program class.
+// WebApplicationFactory<Program> in the test project can't see internal types, so
+// it fails to find the entry point. This partial class declaration makes Program
+// public without changing any behavior at runtime.
+//
+// The "partial" keyword just means "this is part of the same class defined by
+// the top-level statements above." Adding it here is the idiomatic .NET pattern;
+// the alternative is [assembly: InternalsVisibleTo("...")] in the API csproj.
+public partial class Program { }

--- a/MyTowerRegistration.API/Program.cs
+++ b/MyTowerRegistration.API/Program.cs
@@ -24,6 +24,7 @@ using System.Threading.RateLimiting;
 using HotChocolate.Execution;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
+using MyTowerRegistration.API;
 using MyTowerRegistration.Data;
 using MyTowerRegistration.Data.Repositories;
 
@@ -163,16 +164,24 @@ builder.Services.AddCors(options =>
 //   independent PermitLimit budget. A single shared global counter would be
 //   exhausted by one heavy client and deny everyone else.
 //
-// CONFIG:
-//   RateLimiting:PermitLimit   — max requests per window (default 30)
-//   RateLimiting:WindowSeconds — window length in seconds (default 60)
+// CONFIG: see RateLimitingOptions.cs — defaults (30 req / 60 s) live there.
 //   Override in ECS via env vars: RateLimiting__PermitLimit, RateLimiting__WindowSeconds
-int permitLimit   = builder.Configuration.GetValue<int>("RateLimiting:PermitLimit",  defaultValue: 30);
-int windowSeconds = builder.Configuration.GetValue<int>("RateLimiting:WindowSeconds", defaultValue: 60);
+//   Both values validated at startup (≥ 1): app refuses to start if either is zero or negative.
+builder.Services.AddOptions<RateLimitingOptions>()
+    .Bind(builder.Configuration.GetSection("RateLimiting"))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
+RateLimitingOptions rateLimitCfg =
+    builder.Configuration.GetSection("RateLimiting").Get<RateLimitingOptions>()
+    ?? new RateLimitingOptions();
+
+// Shared between AddPolicy and RequireRateLimiting — one string, no typo risk.
+const string GraphQLRateLimitPolicy = "GraphQL";
 
 builder.Services.AddRateLimiter(rateLimiterOptions =>
 {
-    rateLimiterOptions.AddPolicy("GraphQL", httpContext =>
+    rateLimiterOptions.AddPolicy(GraphQLRateLimitPolicy, httpContext =>
         RateLimitPartition.GetFixedWindowLimiter(
             // LIMITATION: all requests that arrive with no RemoteIpAddress (can
             // happen in tests and behind some proxies) fall into one shared
@@ -187,17 +196,37 @@ builder.Services.AddRateLimiter(rateLimiterOptions =>
             partitionKey: httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
             factory: _ => new FixedWindowRateLimiterOptions
             {
-                PermitLimit            = permitLimit,
-                Window                 = TimeSpan.FromSeconds(windowSeconds),
-                QueueProcessingOrder   = QueueProcessingOrder.OldestFirst,
-                QueueLimit             = 0,
+                PermitLimit = rateLimitCfg.PermitLimit,
+                Window      = TimeSpan.FromSeconds(rateLimitCfg.WindowSeconds),
+                QueueLimit  = 0,
             }
         )
     );
 
-    // 429 Too Many Requests is the standard HTTP status for rate limit violations.
-    // The default would be 503 Service Unavailable, which misrepresents the cause.
-    rateLimiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    // OnRejected owns the response — status code, headers, and observability.
+    // Setting RejectionStatusCode instead would not let us add Retry-After or log.
+    rateLimiterOptions.OnRejected = (context, _) =>
+    {
+        // RFC 6585: 429 responses SHOULD include Retry-After so clients know
+        // when to retry rather than hammering the endpoint.
+        // FixedWindowRateLimiter populates MetadataName.RetryAfter with the
+        // time remaining in the current window when it rejects a lease.
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out TimeSpan retryAfter))
+        {
+            context.HttpContext.Response.Headers.RetryAfter =
+                ((int)retryAfter.TotalSeconds).ToString(System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        context.HttpContext.Response.StatusCode = StatusCodes.Status429TooManyRequests;
+
+        ILogger logger = context.HttpContext.RequestServices
+            .GetRequiredService<ILoggerFactory>()
+            .CreateLogger("MyTowerRegistration.RateLimiting");
+        logger.LogWarning("Rate limit exceeded for {IP}",
+            context.HttpContext.Connection.RemoteIpAddress);
+
+        return ValueTask.CompletedTask;
+    };
 });
 
 // Keep OpenAPI support from the template
@@ -293,7 +322,7 @@ app.UseCors("AdminPolicy");
 // inbound GraphQL operation.
 app.UseRateLimiter();
 
-app.MapGraphQL("/api/graphql").RequireRateLimiting("GraphQL");
+app.MapGraphQL("/api/graphql").RequireRateLimiting(GraphQLRateLimitPolicy);
 
 app.Run();
 

--- a/MyTowerRegistration.API/RateLimitingOptions.cs
+++ b/MyTowerRegistration.API/RateLimitingOptions.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MyTowerRegistration.API;
+
+// Typed configuration for the rate limiter, bound from the "RateLimiting" section
+// of appsettings.json (or env vars: RateLimiting__PermitLimit, RateLimiting__WindowSeconds).
+//
+// Using a typed options class instead of raw GetValue<int> calls has three advantages:
+//   1. Defaults live in exactly one place (the property initializers below).
+//   2. ValidateDataAnnotations() + ValidateOnStart() in Program.cs crash the app at
+//      startup if either value is invalid — no silent misconfiguration in production.
+//   3. Any future code that needs these values can inject IOptions<RateLimitingOptions>
+//      rather than referencing magic strings.
+public class RateLimitingOptions
+{
+    [Range(1, int.MaxValue, ErrorMessage = "RateLimiting:PermitLimit must be at least 1.")]
+    public int PermitLimit   { get; init; } = 30;
+
+    [Range(1, int.MaxValue, ErrorMessage = "RateLimiting:WindowSeconds must be at least 1.")]
+    public int WindowSeconds { get; init; } = 60;
+}

--- a/MyTowerRegistration.API/appsettings.json
+++ b/MyTowerRegistration.API/appsettings.json
@@ -9,5 +9,10 @@
 
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=mytower;Username=postgres;Password=YOUR_PASSWORD_HERE"
+  },
+
+  "RateLimiting": {
+    "PermitLimit": 30,
+    "WindowSeconds": 60
   }
 }

--- a/MyTowerRegistration.Tests/MyTowerRegistration.Tests.csproj
+++ b/MyTowerRegistration.Tests/MyTowerRegistration.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/MyTowerRegistration.Tests/RateLimitingTests.cs
+++ b/MyTowerRegistration.Tests/RateLimitingTests.cs
@@ -121,7 +121,7 @@ public class RateLimitingTests
         {
             HttpResponseMessage response = await client.PostAsync("/api/graphql", MakeRequest());
 
-            Assert.NotEqual(HttpStatusCode.TooManyRequests, response.StatusCode,
+            Assert.True(response.StatusCode != HttpStatusCode.TooManyRequests,
                 $"Request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
     }
@@ -140,7 +140,7 @@ public class RateLimitingTests
         for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
         {
             HttpResponseMessage warmup = await client.PostAsync("/api/graphql", MakeRequest());
-            Assert.NotEqual(HttpStatusCode.TooManyRequests, warmup.StatusCode,
+            Assert.True(warmup.StatusCode != HttpStatusCode.TooManyRequests,
                 $"Warmup request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
 
@@ -187,7 +187,7 @@ public class RateLimitingTests
         for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
         {
             HttpResponseMessage warmup = await client.PostAsync("/api/graphql", MakeRequest());
-            Assert.NotEqual(HttpStatusCode.TooManyRequests, warmup.StatusCode,
+            Assert.True(warmup.StatusCode != HttpStatusCode.TooManyRequests,
                 $"Warmup request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
 

--- a/MyTowerRegistration.Tests/RateLimitingTests.cs
+++ b/MyTowerRegistration.Tests/RateLimitingTests.cs
@@ -95,6 +95,13 @@ public class RateLimitingTests
     private static StringContent MakeRequest() =>
         new("""{"query":"{ __typename }"}""", Encoding.UTF8, "application/json");
 
+    // Reads the production permit limit from the factory's loaded configuration —
+    // stays in sync with appsettings.json automatically, no separate constant to maintain.
+    private static int ReadPermitLimit(WebApplicationFactory<Program> factory) =>
+        factory.Services
+            .GetRequiredService<IConfiguration>()
+            .GetValue<int>("RateLimiting:PermitLimit", 30);
+
     // -------------------------------------------------------------------------
     // TESTS
     // -------------------------------------------------------------------------
@@ -105,9 +112,7 @@ public class RateLimitingTests
         // Arrange
         await using WebApplicationFactory<Program> factory = CreateFactory();
         using HttpClient client = factory.CreateClient();
-        int permitLimit = factory.Services
-            .GetRequiredService<IConfiguration>()
-            .GetValue<int>("RateLimiting:PermitLimit", 30);
+        int permitLimit = ReadPermitLimit(factory);
 
         // Act + Assert — every request within the window should pass through.
         // "Non-429" means the rate limiter allowed the request; the response body
@@ -116,7 +121,8 @@ public class RateLimitingTests
         {
             HttpResponseMessage response = await client.PostAsync("/api/graphql", MakeRequest());
 
-            Assert.NotEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, response.StatusCode,
+                $"Request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
     }
 
@@ -126,14 +132,16 @@ public class RateLimitingTests
         // Arrange
         await using WebApplicationFactory<Program> factory = CreateFactory();
         using HttpClient client = factory.CreateClient();
-        int permitLimit = factory.Services
-            .GetRequiredService<IConfiguration>()
-            .GetValue<int>("RateLimiting:PermitLimit", 30);
+        int permitLimit = ReadPermitLimit(factory);
 
-        // Exhaust the full budget (permitLimit requests allowed, all non-429)
+        // Exhaust the full budget — assert each warmup request passes so that
+        // a misconfigured factory (e.g. rate limiter not wired) fails here with a
+        // clear message rather than a confusing false-positive on the final assertion.
         for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
         {
-            await client.PostAsync("/api/graphql", MakeRequest());
+            HttpResponseMessage warmup = await client.PostAsync("/api/graphql", MakeRequest());
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, warmup.StatusCode,
+                $"Warmup request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
 
         // Act — this is the (permitLimit + 1)th request in the same window
@@ -174,13 +182,13 @@ public class RateLimitingTests
         // Arrange
         await using WebApplicationFactory<Program> factory = CreateFactory();
         using HttpClient client = factory.CreateClient();
-        int permitLimit = factory.Services
-            .GetRequiredService<IConfiguration>()
-            .GetValue<int>("RateLimiting:PermitLimit", 30);
+        int permitLimit = ReadPermitLimit(factory);
 
         for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
         {
-            await client.PostAsync("/api/graphql", MakeRequest());
+            HttpResponseMessage warmup = await client.PostAsync("/api/graphql", MakeRequest());
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, warmup.StatusCode,
+                $"Warmup request {requestNumber} of {permitLimit} was unexpectedly rate-limited.");
         }
 
         // Act

--- a/MyTowerRegistration.Tests/RateLimitingTests.cs
+++ b/MyTowerRegistration.Tests/RateLimitingTests.cs
@@ -1,0 +1,194 @@
+// =============================================================================
+// INTEGRATION TESTS — Rate Limiting
+//
+// These tests verify the rate-limiting middleware end-to-end: a real HTTP
+// request flows through the full ASP.NET Core pipeline and we assert on the
+// HTTP status code returned.
+//
+// This is a different kind of test from UserMutationTests.cs:
+//
+//   UserMutationTests.cs — UNIT tests
+//     - Calls the C# mutation method directly.
+//     - Mocks the repository with Moq.
+//     - Fast, no network, no HTTP stack.
+//     - Tests business logic in isolation.
+//
+//   RateLimitingTests.cs — INTEGRATION tests
+//     - Spins up the full ASP.NET Core app in-process via WebApplicationFactory.
+//     - Sends real HTTP requests through the middleware pipeline.
+//     - Uses an in-memory EF Core database (no PostgreSQL needed).
+//     - Tests that middleware wiring is correct — something unit tests can't cover.
+//
+// Compare to Node.js / supertest:
+//   const app = express(); /* ... */
+//   const res = await request(app).post('/graphql').send({ query: '{ __typename }' });
+//   expect(res.status).toBe(200);
+//
+// WebApplicationFactory is the .NET equivalent of supertest: it hosts the app
+// in-process and gives you an HttpClient wired to it.
+//
+// WHY { __typename }:
+//   GraphQL's __typename is a built-in meta-field that returns the type name
+//   ("Query"). It requires zero resolver execution and no database access,
+//   so it's the lightest possible valid GraphQL request — perfect for
+//   exercising the middleware layer without side effects.
+//
+// HOW tests read PermitLimit:
+//   The rate limiter reads PermitLimit from configuration at startup, before
+//   WebApplicationFactory's ConfigureAppConfiguration hook fires for minimal-
+//   API apps — so we can't inject a test-only value. Instead, each test reads
+//   the limit back out of the factory's already-loaded IConfiguration:
+//
+//     factory.Services.GetRequiredService<IConfiguration>()
+//                      .GetValue<int>("RateLimiting:PermitLimit", 30)
+//
+//   This means tests automatically stay in sync if appsettings.json changes —
+//   no separate constant to update.
+// =============================================================================
+
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MyTowerRegistration.Data;
+using System.Net;
+using System.Text;
+
+namespace MyTowerRegistration.Tests;
+
+public class RateLimitingTests
+{
+    // -------------------------------------------------------------------------
+    // HELPERS
+    // -------------------------------------------------------------------------
+
+    // Creates a fresh WebApplicationFactory per test so each starts with an
+    // empty rate-limit counter. Sharing a factory via IClassFixture would let
+    // one test's requests exhaust another test's budget — order-dependent failures.
+    //
+    // ConfigureServices: swaps the real PostgreSQL DbContext for in-memory so
+    // the server starts cleanly without a running database. The rate limiter
+    // fires before any resolver runs, so the DB is never touched in the
+    // "expect 429" case — but we still swap it so the "expect non-429" cases
+    // can complete a full request cycle without error.
+    private static WebApplicationFactory<Program> CreateFactory()
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Remove the real PostgreSQL options registration and replace
+                // it with an in-memory database so tests don't need a server.
+                ServiceDescriptor? postgresDescriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+                if (postgresDescriptor is not null)
+                    services.Remove(postgresDescriptor);
+
+                services.AddDbContext<AppDbContext>(options =>
+                    options.UseInMemoryDatabase("RateLimitTestDb"));
+            });
+        });
+    }
+
+    // HttpContent is disposed after a PostAsync call, so create a fresh instance
+    // per request. The { __typename } body is the lightest valid GraphQL document.
+    private static StringContent MakeRequest() =>
+        new("""{"query":"{ __typename }"}""", Encoding.UTF8, "application/json");
+
+    // -------------------------------------------------------------------------
+    // TESTS
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GraphQL_RequestsUpToPermitLimit_ReturnNon429()
+    {
+        // Arrange
+        await using WebApplicationFactory<Program> factory = CreateFactory();
+        using HttpClient client = factory.CreateClient();
+        int permitLimit = factory.Services
+            .GetRequiredService<IConfiguration>()
+            .GetValue<int>("RateLimiting:PermitLimit", 30);
+
+        // Act + Assert — every request within the window should pass through.
+        // "Non-429" means the rate limiter allowed the request; the response body
+        // may contain GraphQL errors (e.g. no such field) but that's irrelevant here.
+        for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
+        {
+            HttpResponseMessage response = await client.PostAsync("/api/graphql", MakeRequest());
+
+            Assert.NotEqual(HttpStatusCode.TooManyRequests, response.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task GraphQL_FirstRequestExceedingPermitLimit_Returns429()
+    {
+        // Arrange
+        await using WebApplicationFactory<Program> factory = CreateFactory();
+        using HttpClient client = factory.CreateClient();
+        int permitLimit = factory.Services
+            .GetRequiredService<IConfiguration>()
+            .GetValue<int>("RateLimiting:PermitLimit", 30);
+
+        // Exhaust the full budget (permitLimit requests allowed, all non-429)
+        for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
+        {
+            await client.PostAsync("/api/graphql", MakeRequest());
+        }
+
+        // Act — this is the (permitLimit + 1)th request in the same window
+        HttpResponseMessage limitedResponse = await client.PostAsync("/api/graphql", MakeRequest());
+
+        // Assert
+        Assert.Equal(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task GraphQL_RequestExceedingLimit_ResponseBodyIsEmpty()
+    {
+        // WHAT this tests and WHY it matters:
+        //   The rate limiter short-circuits before Hot Chocolate runs, so ASP.NET
+        //   Core returns a bare 429 with no body — not the GraphQL error envelope
+        //   { "errors": [{ "message": "..." }] } that Hot Chocolate would produce.
+        //
+        //   A Blazor (or any other) client that tries to deserialize the 429 body
+        //   as a GraphQL response will get null/empty fields with no exception.
+        //   The silent failure looks like a successful empty response rather than
+        //   an error. Clients MUST branch on the HTTP status code first:
+        //
+        //     if (response.StatusCode == HttpStatusCode.TooManyRequests) { ... }
+        //     // only then attempt to read the body as GraphQL JSON
+        //
+        // WHY this test is fragile (and why we keep it anyway):
+        //   Assert.Empty(body) relies on ASP.NET Core's rate limiter never writing
+        //   a body on 429 — which is true today but is an undocumented
+        //   implementation detail. A future middleware (e.g. a problem-details
+        //   formatter added to the pipeline) could legally add a body to 429
+        //   responses, and this test would fail for the wrong reason.
+        //
+        //   We keep the test because it documents a real client contract: do not
+        //   parse the 429 body. If it ever fails due to a body being added, the
+        //   right fix is to update both the test and the client-side 429 handler
+        //   together — not just delete the assertion.
+
+        // Arrange
+        await using WebApplicationFactory<Program> factory = CreateFactory();
+        using HttpClient client = factory.CreateClient();
+        int permitLimit = factory.Services
+            .GetRequiredService<IConfiguration>()
+            .GetValue<int>("RateLimiting:PermitLimit", 30);
+
+        for (int requestNumber = 1; requestNumber <= permitLimit; requestNumber++)
+        {
+            await client.PostAsync("/api/graphql", MakeRequest());
+        }
+
+        // Act
+        HttpResponseMessage limitedResponse = await client.PostAsync("/api/graphql", MakeRequest());
+        string body = await limitedResponse.Content.ReadAsStringAsync();
+
+        // Assert
+        Assert.Equal(HttpStatusCode.TooManyRequests, limitedResponse.StatusCode);
+        Assert.Empty(body);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds ASP.NET Core built-in fixed-window rate limiting to `/api/graphql` (30 req / 60 s per IP by default)
- Config-driven via `RateLimiting:PermitLimit` / `RateLimiting:WindowSeconds` in appsettings.json; overridable in ECS via env vars
- Returns HTTP 429 with a `Retry-After` header (RFC 6585) and logs the client IP on rejection
- Backed by integration tests via `WebApplicationFactory<Program>` — no PostgreSQL needed

## Changes

- **`RateLimitingOptions.cs`** — typed options class with startup validation (`ValidateOnStart`); bad config crashes the app rather than silently misconfiguring it
- **`Program.cs`** — `AddRateLimiter` with per-IP `FixedWindowLimiter`, `OnRejected` callback for `Retry-After` + logging, `const` policy name shared between registration and endpoint wiring
- **`RateLimitingTests.cs`** — 3 integration tests covering: requests within budget pass, first over-budget request returns 429, 429 body is empty (documents that clients must check status code, not body)
- **`*.csproj`** — adds `Microsoft.AspNetCore.Mvc.Testing` for `WebApplicationFactory`

## Known limitation (documented in code)

Behind an ALB or reverse proxy, `RemoteIpAddress` will be the balancer's IP. Fix tracked: add `UseForwardedHeaders` before `UseRateLimiter` when the ALB is wired up.

## Test plan

- [ ] `dotnet test` — all tests pass (3 new integration tests + existing unit tests)
- [ ] Set `RateLimiting:PermitLimit = 0` in appsettings.json locally — app should refuse to start with a validation error
- [ ] Manually hit `/api/graphql` more than 30 times in 60 s — confirm 429 + `Retry-After` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)