### PR TITLE
Fix Moq parameter-count mismatch in RegisterUser tests

### DIFF
--- a/MyTowerRegistration.Tests/UserMutationTests.cs
+++ b/MyTowerRegistration.Tests/UserMutationTests.cs
@@ -51,7 +51,7 @@ public class UserMutationTests
         _mockRepo.Setup(repo => repo.EmailExistsAsync(It.IsAny<string>(), CancellationToken.None))
             .ReturnsAsync(false);
         _mockRepo.Setup(repo => repo.AddAsync(It.IsAny<User>(), CancellationToken.None))
-            .ReturnsAsync((User u) => { u.Id = 1; return u; });
+            .ReturnsAsync((User u, CancellationToken _) => { u.Id = 1; return u; });
 
         var input = new RegisterUserInput("testuser", "test@example.com", "Password123");
 
@@ -244,8 +244,8 @@ public class UserMutationTests
 
         User? capturedUser = null;
         _mockRepo.Setup(repo => repo.AddAsync(It.IsAny<User>(), CancellationToken.None))
-            .Callback<User>(user => capturedUser = user)  // Capture the entity
-            .ReturnsAsync((User u) => u);
+            .Callback<User, CancellationToken>((user, _) => capturedUser = user)
+            .ReturnsAsync((User u, CancellationToken _) => u);
 
         var input = new RegisterUserInput("user", "user@test.com", "MySecret");
 


### PR DESCRIPTION
## What was broken

Two tests in `UserMutationTests` failed at runtime with `System.ArgumentException` from Moq. Both failures had the same root cause: the Moq lambda expressions used single-parameter forms for `AddAsync`, which is a **two-parameter** method (`User user, CancellationToken ct`).

Moq enforces strict parameter-count matching: `Callback<T1>` only works when the mocked method has exactly one parameter, and `ReturnsAsync(Func<T1, TResult>)` similarly. Passing the wrong arity causes an `ArgumentException` at the point the setup is executed (not at test arrangement time, but when the mock is first invoked).

## Fix per test

### `RegisterUser_WithValidInput_ReturnsUserAndNoErrors`

**Error:** `Invalid callback. Setup on method with 2 parameter(s) cannot invoke callback with different number of parameters (1).`

```csharp
// Before — Func<User, User> has 1 input, but AddAsync has 2
.ReturnsAsync((User u) => { u.Id = 1; return u; });

// After — Func<User, CancellationToken, User> matches the method signature
.ReturnsAsync((User u, CancellationToken _) => { u.Id = 1; return u; });
```

### `RegisterUser_PasswordIsHashed_NotStoredPlaintext`

**Error:** `Invalid callback. Setup on method with parameters (User, CancellationToken) cannot invoke callback with parameters (User).`

```csharp
// Before — Callback<User> declares 1 parameter, method has 2
.Callback<User>(user => capturedUser = user)
.ReturnsAsync((User u) => u);

// After — both match the 2-parameter signature
.Callback<User, CancellationToken>((user, _) => capturedUser = user)
.ReturnsAsync((User u, CancellationToken _) => u);
```

## Why the tests, not the production code

`RegisterUser` in `UserMutations.cs` correctly calls `userRepository.AddAsync(newUser, ct)` with both parameters. The production code is fine; only the Moq setup expressions in the tests were wrong.

## Verification

All 16 tests pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)