### PR TITLE
Add UpdateUser GUI: inline edit row and password modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -367,3 +367,4 @@ FodyWeavers.xsd
 
 #Environment variables file, see .env.example for placeholder values. This file should not be checked in to source control as it may contain sensitive information.
 .env
+MyTowerRegistration.API/appsettings.Development.json

--- a/MyTowerRegistration.Admin/GraphQL/UpdateUser.graphql
+++ b/MyTowerRegistration.Admin/GraphQL/UpdateUser.graphql
@@ -1,0 +1,27 @@
+# UpdateUser — modify a user's username, email, and/or password.
+#
+# Patch semantics: only non-null fields are applied. Omit a field entirely
+# (or pass null) to leave it unchanged. All three nullable means this is
+# a no-op, which the resolver handles gracefully.
+#
+# StrawberryShake generates:
+#   UpdateUserAsync(int id, string? username, string? email, string? password)
+#     → IUpdateUserResult
+#   result.Data.UpdateUser.User          ← the updated user (nullable)
+#   result.Data.UpdateUser.Errors        ← error list (nullable)
+#   result.Data.UpdateUser.Errors[0].Code    ← enum: USERNAME_TAKEN, etc.
+#   result.Data.UpdateUser.Errors[0].Message ← human-readable explanation
+
+mutation UpdateUser($id: Int!, $username: String, $email: String, $password: String) {
+  updateUser(input: { id: $id, username: $username, email: $email, password: $password }) {
+    user {
+      id
+      username
+      email
+    }
+    errors {
+      message
+      code
+    }
+  }
+}

--- a/MyTowerRegistration.Admin/MyTowerRegistration.Admin.csproj
+++ b/MyTowerRegistration.Admin/MyTowerRegistration.Admin.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" PrivateAssets="all" />
-    <PackageReference Include="StrawberryShake.Blazor" Version="15.1.14" />
+    <PackageReference Include="StrawberryShake.Blazor" Version="15.1.15" />
   </ItemGroup>
 
   <!-- ==========================================================================

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -122,7 +122,6 @@ else {
                             </button>
                         </td>
                         <td>
-                            😇
                         </td>
 
                     </tr>

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -66,11 +66,6 @@ else {
                     <td>@user.Email</td>
                     <td>@user.CreatedAt.ToString("yyyy-MM-dd")</td>
                     <td>
-                        @* TODO: Render an Edit / Close toggle button.
-                           - If editingUserId == user.Id, show "Close" and call CancelEdit()
-                           - Otherwise show "Edit" and call StartEdit(user)
-                           - Disable while _isUpdating is true (same idea as _deletionId for Delete)
-                           Blazor tip: @onclick takes a lambda — "() => StartEdit(user)" *@
                         @if (_activeEdit?.UserId == user.Id) {
                             <button class="btn btn-outline-secondary btn-sm"
                                     @onclick="CancelEdit"
@@ -131,15 +126,14 @@ else {
                         </td>
 
                     </tr>
-                    @if (_updateErrorMessage is not null)
-                    {
+                    @if (_updateErrorMessage is not null) {
                         <tr>
                             <td colspan="6">
                                 <div class="alert alert-danger mb-0">@_updateErrorMessage</div>
                             </td>
                         </tr>
                     }
-                } 
+                }
                 @*// End if this user is being actively edited*@
             } @*End For Each user to be displayed*@
         </tbody>
@@ -163,28 +157,28 @@ else {
                 <button type="button" class="btn-close" @onclick="ClosePasswordModal"></button>
             </div>
             <div class="modal-body">
-                @* TODO: Password input field — bind to _editPassword.
-                   Use type="password" so the browser masks the input.
-                   Blazor tip: <input type="password" class="form-control" @bind="_editPassword" /> *@
                 <label class="form-label">New Password</label>
                 <input type="password" class="form-control" @bind="_editPassword" />
-                
-                @* TODO: Confirm password field — bind to _editPasswordConfirm.
-                   We'll validate client-side that both fields match before sending. *@
+
                 <label class="form-label">Repeat Password</label>
                 <input type="password" class="form-control" @bind="_editPasswordConfirm" />
-                
+
                 @* Error message area for password-specific errors *@
                 @if (_passwordErrorMessage is not null) {
                     <div class="alert alert-danger mt-2">@_passwordErrorMessage</div>
                 }
             </div>
             <div class="modal-footer">
-                @* TODO: Save Password button — calls HandlePasswordUpdate() on click.
-                   Show "⏳ Saving..." while _isUpdatingPassword is true.
-                   Disable while _isUpdatingPassword is true. *@
-
-                @* TODO: Cancel button — calls ClosePasswordModal() on click. *@
+                <button class="btn btn-success btn-sm"
+                        @onclick="HandlePasswordUpdate"
+                        @disabled="@_isUpdatingPassword">
+                    @(_isUpdatingPassword ? "📝 Saving..." : "Save")
+                </button>
+                <button class="btn btn-secondary btn-sm ms-1"
+                        @onclick="ClosePasswordModal"
+                        @disabled ="@_isUpdatingPassword">
+                    Cancel
+                </button>
             </div>
         </div>
     </div>
@@ -269,13 +263,12 @@ else {
     // =============================================================================
     protected override async Task OnInitializedAsync()
     {
-
         await RefreshUsers();
     }
 
     private async Task RefreshUsers()
     {
-        _isLoading = true; 
+        _isLoading = true;
         try {
             // StrawberryShake call: Client.GetUsers is the generated IGetUsersQuery.
             // ExecuteAsync() sends the GetUsers.graphql operation over HTTP, deserializes
@@ -336,16 +329,16 @@ else {
 
             // result.Data is non-null because top-level Errors was empty.
             IDeleteUser_DeleteUser payload = result.Data!.DeleteUser;
+            if (payload.User is not null) {
+                // Remove the deleted row from the local list without re-fetching.
+                _users.RemoveAll(u => u.Id == userIdToDelete);
+            }
 
-            if (payload.Errors is { Count: > 0 } validationErrors) {
+            else if (payload.Errors is { Count: > 0 } validationErrors) {
                 // The API returns validation errors as data (error-as-data pattern),
                 // not as HTTP errors. We surface them here.
                 // e.Code is DeleteUserErrorCode enum — compare to old code where it was string.
                 _deletionErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
-            }
-            else if (payload.User is not null) {
-                // Remove the deleted row from the local list without re-fetching.
-                _users.RemoveAll(u => u.Id == userIdToDelete);
             }
             else {
                 // Fallback: server returned HTTP 200, no top-level errors, no payload errors,
@@ -373,8 +366,6 @@ else {
         _draftEmail = model?.Email;
         _updateErrorMessage = null;
     }
-
-
 
     // =========================================================================
     // StartEdit — opens the edit panel for a row, pre-filling the fields
@@ -422,8 +413,6 @@ else {
     //   1. top-level result.Errors  — transport/auth errors
     //   2. payload.Errors           — business rule errors (UsernameTaken, etc.)
     //   3. else                     — unexpected shape fallback
-    //
-    // TODO: Implement this method.
     // =========================================================================
     private async Task HandleUpdate()
     {
@@ -439,25 +428,24 @@ else {
 
             // var topLevelErrors = result.Errors
             // if (topLevelErrors is not null && topLevelErrors.Count > 0) {
-            // ... topLevelErrors.Select(e => e.Messge)
+            // ... topLevelErrors.Select(e => e.Message)
             // }
             // Idiomatic form — null check, count check, and variable binding in one:
-            if (result.Errors is { Count: > 0} topLevelErrors)
-            {
+            if (result.Errors is { Count: > 0 } topLevelErrors) {
                 IEnumerable<string> errorList = topLevelErrors.Select(error => error.Message);
-                _updateErrorMessage = $"GraphQL Errors(s): {string.Join("; ", errorList)}";
+                _updateErrorMessage = $"GraphQL error(s): {string.Join("; ", errorList)}";
                 return;
             }
 
             // This presumes that Strawberry Shake's payload delivers Data in non-error conditions
             IUpdateUser_UpdateUser payload = result.Data!.UpdateUser;
 
-            if (payload.Errors is {Count: > 0} validationErrors) {
-                _updateErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
-            }
-            else if (payload.User is not null) {
+            if (payload.User is not null) {
                 await RefreshUsers();
                 CancelEdit();
+            }
+            else if (payload.Errors is { Count: > 0 } validationErrors) {
+                _updateErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
             }
             else {
                 _updateErrorMessage = "Update did not return a result. The user may not have been saved.";
@@ -483,24 +471,24 @@ else {
     // and add a tiny JS helper in index.html:
     //   window.bootstrapModalShow = el => bootstrap.Modal.getOrCreateInstance(el).show();
     //   window.bootstrapModalHide = el => bootstrap.Modal.getOrCreateInstance(el).hide();
-    //
-    // TODO: Clear _editPassword, _editPasswordConfirm, _passwordErrorMessage.
-    //       Call the JS interop to show the modal.
     // =========================================================================
     private async Task OpenPasswordModal()
     {
-        throw new NotImplementedException();
+        _editPassword = null;
+        _editPasswordConfirm = null;
+        _passwordErrorMessage = null;
+        await JS.InvokeVoidAsync("bootstrapModalShow", _passwordModalRef);
     }
 
     // =========================================================================
     // ClosePasswordModal — hides the Bootstrap modal via JS interop.
-    //
-    // TODO: Call the JS interop to hide the modal.
-    //       Clear password fields and _passwordErrorMessage.
     // =========================================================================
     private async Task ClosePasswordModal()
     {
-        throw new NotImplementedException();
+        _editPassword = null;
+        _editPasswordConfirm = null;
+        _passwordErrorMessage = null;
+        await JS.InvokeVoidAsync("bootstrapModalHide", _passwordModalRef);
     }
 
     // =========================================================================
@@ -511,16 +499,59 @@ else {
     //   - _editPassword must equal _editPasswordConfirm (show _passwordErrorMessage if not)
     //
     // Then calls Client.UpdateUser.ExecuteAsync(
-    //     editingUserId!.Value, username: null, email: null, password: _editPassword)
+    //     _activeEdit!.UserId, username: null, email: null, password: _editPassword)
     //
     // On success: call ClosePasswordModal(). No table update needed (password
     // isn't displayed). On error: set _passwordErrorMessage (stay in the modal).
-    //
-    // TODO: Implement this method.
     // =========================================================================
     private async Task HandlePasswordUpdate()
     {
-        throw new NotImplementedException();
+        if (_activeEdit is null) return;
+
+        if (string.IsNullOrWhiteSpace(_editPassword)) {
+            _passwordErrorMessage = "Password cannot be empty";
+            return;
+        }
+
+        if (_editPassword != _editPasswordConfirm) {
+            _passwordErrorMessage = "Passwords do not match";
+            return;
+        }
+
+        _passwordErrorMessage = null;
+        _isUpdatingPassword = true;
+
+        try {
+            IOperationResult<IUpdateUserResult> result = await Client.UpdateUser.ExecuteAsync(
+                _activeEdit.UserId, username: null, email: null, password: _editPassword);
+
+            if (result.Errors is { Count: > 0 } topLevelErrors) {
+                IEnumerable<string> errorMessages = topLevelErrors.Select(error => error.Message);
+                string errorString = string.Join("; ", errorMessages);
+                _passwordErrorMessage = $"GraphQL error(s): {errorString}";
+                return;
+            }
+
+            IUpdateUser_UpdateUser payload = result.Data!.UpdateUser;
+
+            if (payload.User is not null) {
+                await ClosePasswordModal();
+            }
+            else if (payload.Errors is { Count: > 0 } validationErrors) {
+                IEnumerable<string> errorMessages = validationErrors.Select(error => $"{error.Code} : {error.Message}");
+                string errorString = string.Join(" | ", errorMessages);
+                _passwordErrorMessage = errorString;
+            }
+            else {
+                _passwordErrorMessage = "Update did not return a result. The password may not have been saved.";
+            }
+        }
+        catch (Exception ex) {
+            _passwordErrorMessage = $"Unexpected error: {ex.Message}";
+        }
+        finally {
+            _isUpdatingPassword = false;
+        }
     }
 }
 @* End @code *@

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -422,9 +422,13 @@ else {
         _isUpdating = true;
 
         try {
+            // Null means "don't change anything" in the API
+            string? updatedUsername = _draftUsername != _activeEdit.Username ? _draftUsername : null;
+            string? updatedEmail = _draftEmail != _activeEdit.Email ? _draftEmail : null;
+
             IOperationResult<IUpdateUserResult> result =
-                await Client.UpdateUser.ExecuteAsync(
-                    _activeEdit.UserId, _draftUsername, _draftEmail, password: null);
+                await Client.UpdateUser.ExecuteAsync(_activeEdit.UserId, 
+                    updatedUsername, updatedEmail, password: null);
 
             // var topLevelErrors = result.Errors
             // if (topLevelErrors is not null && topLevelErrors.Count > 0) {

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -1,7 +1,7 @@
 @* =============================================================================
    USERS.RAZOR — User List Page
 
-   This page displays all registered users fetched via StrawberryShake.
+   This page displays all registered _users fetched via StrawberryShake.
 
    What changed from the raw HttpClient version:
      - @inject HttpClient Http  →  @inject IMyTowerClient Client
@@ -35,14 +35,14 @@
 
 <h1>Users</h1>
 
-@if (isLoading) {
+@if (_isLoading) {
     @* Show a spinner while the GraphQL query is in flight.
        In Blazor WASM, this renders client-side as soon as the component mounts
        and OnInitializedAsync begins its await. *@
     <p><em>Loading...</em></p>
 }
-else if (errorMessage is not null) {
-    <div class="alert alert-danger">@errorMessage</div>
+else if (_errorMessage is not null) {
+    <div class="alert alert-danger">@_errorMessage</div>
 }
 else {
     <table class="table">
@@ -59,7 +59,7 @@ else {
         <tbody>
             @* @foreach in a template is C# — the @ prefix signals to Razor
                that what follows is C# code, not HTML markup. *@
-            @foreach (var user in users) {
+            @foreach (var user in _users) {
                 <tr>
                     <td>@user.Id</td>
                     <td>@user.Username</td>
@@ -69,22 +69,22 @@ else {
                         @* TODO: Render an Edit / Close toggle button.
                            - If editingUserId == user.Id, show "Close" and call CancelEdit()
                            - Otherwise show "Edit" and call StartEdit(user)
-                           - Disable while isUpdating is true (same idea as deletionId for Delete)
+                           - Disable while _isUpdating is true (same idea as _deletionId for Delete)
                            Blazor tip: @onclick takes a lambda — "() => StartEdit(user)" *@
                     </td>
                     <td>
                         <button class="btn btn-danger btn-sm"
                                 @onclick="() => HandleDelete(user.Id)"
-                                @disabled="@(deletionId is not null)"
+                                @disabled="@(_deletionId is not null)"
                         >
-                            @(deletionId == user.Id ? "⏳ Deleting..." : "Delete")
+                            @(_deletionId == user.Id ? "⏳ Deleting..." : "Delete")
                         </button>
                     </td>
                 </tr>
 
                 @* Edit panel — expands below the row when this user is being edited.
                    colspan="6" spans all columns so the panel fills the table width. *@
-                @if (editingUserId == user.Id) {
+                @if (_activeEdit?.UserId == user.Id) {
                     <tr>
                         <td colspan="6">
                             <div class="p-3 border rounded bg-light">
@@ -104,16 +104,16 @@ else {
                                    Style: btn btn-outline-secondary btn-sm *@
 
                                 @* TODO: Save button — calls HandleUpdate() on click.
-                                   Show "⏳ Saving..." text while isUpdating is true.
-                                   Disable while isUpdating is true.
+                                   Show "⏳ Saving..." text while _isUpdating is true.
+                                   Disable while _isUpdating is true.
                                    Style: btn btn-primary btn-sm *@
 
                                 @* TODO: Cancel button — calls CancelEdit() on click.
                                    Style: btn btn-secondary btn-sm ms-2 *@
 
-                                @* Error message area — only shown when updateErrorMessage is set *@
-                                @if (updateErrorMessage is not null) {
-                                    <div class="alert alert-danger mt-2">@updateErrorMessage</div>
+                                @* Error message area — only shown when _updateErrorMessage is set *@
+                                @if (_updateErrorMessage is not null) {
+                                    <div class="alert alert-danger mt-2">@_updateErrorMessage</div>
                                 }
                             </div>
                         </td>
@@ -123,8 +123,8 @@ else {
         </tbody>
     </table>
 
-    @if (deletionErrorMessage is not null) {
-        <div class="alert alert-danger">@deletionErrorMessage</div>
+    @if (_deletionErrorMessage is not null) {
+        <div class="alert alert-danger">@_deletionErrorMessage</div>
     }
 }
 
@@ -133,7 +133,7 @@ else {
    A Bootstrap modal rendered as a Razor conditional block.
    @ref captures the DOM element so JS interop can call bootstrap.Modal.show/hide.
    ============================================================================= *@
-<div class="modal fade" tabindex="-1" @ref="passwordModalRef">
+<div class="modal fade" tabindex="-1" @ref="_passwordModalRef">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
@@ -141,22 +141,22 @@ else {
                 <button type="button" class="btn-close" @onclick="ClosePasswordModal"></button>
             </div>
             <div class="modal-body">
-                @* TODO: Password input field — bind to editPassword.
+                @* TODO: Password input field — bind to _editPassword.
                    Use type="password" so the browser masks the input.
-                   Blazor tip: <input type="password" class="form-control" @bind="editPassword" /> *@
+                   Blazor tip: <input type="password" class="form-control" @bind="_editPassword" /> *@
 
-                @* TODO: Confirm password field — bind to editPasswordConfirm.
+                @* TODO: Confirm password field — bind to _editPasswordConfirm.
                    We'll validate client-side that both fields match before sending. *@
 
                 @* Error message area for password-specific errors *@
-                @if (passwordErrorMessage is not null) {
-                    <div class="alert alert-danger mt-2">@passwordErrorMessage</div>
+                @if (_passwordErrorMessage is not null) {
+                    <div class="alert alert-danger mt-2">@_passwordErrorMessage</div>
                 }
             </div>
             <div class="modal-footer">
                 @* TODO: Save Password button — calls HandlePasswordUpdate() on click.
-                   Show "⏳ Saving..." while isUpdatingPassword is true.
-                   Disable while isUpdatingPassword is true. *@
+                   Show "⏳ Saving..." while _isUpdatingPassword is true.
+                   Disable while _isUpdatingPassword is true. *@
 
                 @* TODO: Cancel button — calls ClosePasswordModal() on click. *@
             </div>
@@ -172,49 +172,57 @@ else {
     // When any of these fields change and the component re-renders, Blazor
     // efficiently diffs the virtual DOM and applies only the minimal DOM changes.
     //
-    // users is List<IGetUsers_Users> — a generated StrawberryShake interface type
+    // _users is List<IGetUsers_Users> — a generated StrawberryShake interface type
     // whose properties (Id, Username, Email, CreatedAt) come directly from the
     // fields selected in GraphQL/GetUsers.graphql. If we ever change the selection
     // set in that .graphql file, this type updates at the next build.
     // =============================================================================
 
-    private bool isLoading = true;
-    private string? errorMessage;
-    private List<IGetUsers_Users> users = new();
+    private bool _isLoading = true;
+    private string? _errorMessage;
+    private List<IGetUsers_Users> _users = new();
 
-    // deletionId: tracks which row's delete button is in-flight (disables it during the request)
-    // deletionErrorMessage: holds any delete error to display in the UI
-    private int? deletionId;
-    private string? deletionErrorMessage;
+    // _deletionId: tracks which row's delete button is in-flight (disables it during the request)
+    // _deletionErrorMessage: holds any delete error to display in the UI
+    private int? _deletionId;
+    private string? _deletionErrorMessage;
 
     // =============================================================================
     // EDIT PANEL STATE
     //
-    // editingUserId: which row's edit panel is open (null = none)
-    // editUsername / editEmail: two-way bound to the edit panel's input fields
-    // isUpdating: true while the UpdateUser mutation is in-flight
-    // updateErrorMessage: validation or server errors from the update
+    // EditOriginals: Immutable snapshot of the user's values at the moment Edit was clicked
+    // _activeEdit: null when no row is open, otherwise points to the original values of the row
+    // _draft*Field*: mutable 
     // =============================================================================
-    private int? editingUserId;
-    private string? editUsername;
-    private string? editEmail;
-    private bool isUpdating;
-    private string? updateErrorMessage;
+
+    private record EditOriginals(int UserId, string Username, string Email);
+
+    /// <summary>_activeEdit: null when no row is open, otherwise points to the original values of the row.</summary>
+    private EditOriginals? _activeEdit;   // null = no row is open
+    private string? _draftUsername;       // @bind target — mutable copy
+    private string? _draftEmail;          // @bind target — mutable copy
+
+    /// <summary>
+    /// True only during the UpdateUser HTTP round-trip. Distinct from
+    /// <c>_activeEdit</c>, which stays set the entire time the panel is open.
+    /// </summary>
+    private bool _isUpdating;
+    private string? _updateErrorMessage;
 
     // =============================================================================
     // PASSWORD MODAL STATE
     //
-    // passwordModalRef: ElementReference captured by @ref on the modal <div>.
+    // _passwordModalRef: ElementReference captured by @ref on the modal <div>.
     //   Used by JS interop to call bootstrap.Modal.getOrCreateInstance(el).show/hide.
-    // editPassword / editPasswordConfirm: bound to the two password fields
-    // isUpdatingPassword: true while the password-only UpdateUser call is in-flight
-    // passwordErrorMessage: validation or server errors for the password change
+    // _editPassword / _editPasswordConfirm: bound to the two password fields
+    // _isUpdatingPassword: true while the password-only UpdateUser call is in-flight
+    // _passwordErrorMessage: validation or server errors for the password change
     // =============================================================================
-    private ElementReference passwordModalRef;
-    private string? editPassword;
-    private string? editPasswordConfirm;
-    private bool isUpdatingPassword;
-    private string? passwordErrorMessage;
+    private ElementReference _passwordModalRef;
+    private string? _editPassword;
+    private string? _editPasswordConfirm;
+    private bool _isUpdatingPassword;
+    private string? _passwordErrorMessage;
 
     // =============================================================================
     // LIFECYCLE: OnInitializedAsync
@@ -251,30 +259,30 @@ else {
             IOperationResult<IGetUsersResult> result = await Client.GetUsers.ExecuteAsync();
 
             if (result.Errors is { Count: > 0 } topLevelErrors) {
-                errorMessage = $"GraphQL error(s): {string.Join("; ", topLevelErrors.Select(e => e.Message))}";
+                _errorMessage = $"GraphQL error(s): {string.Join("; ", topLevelErrors.Select(e => e.Message))}";
                 return;
             }
 
             // result.Data is non-null here because Errors was empty.
             // Users is IReadOnlyList<IGetUsers_Users> — we ToList() so we can RemoveAll()
             // later when the user deletes a row without re-fetching the full list.
-            users = result.Data!.Users.ToList();
+            _users = result.Data!.Users.ToList();
         }
         catch (Exception ex) {
-            errorMessage = $"Failed to load users: {ex.Message}";
+            _errorMessage = $"Failed to load users: {ex.Message}";
         }
         finally {
             // Always clear the loading state, even if an exception occurred.
             // Without this, the spinner would spin forever on error.
-            isLoading = false;
+            _isLoading = false;
         }
     }
 
     private async Task HandleDelete(int userIdToDelete)
     {
-        if (deletionId is not null) return; // can only delete one at a time
-        deletionErrorMessage = null;
-        deletionId = userIdToDelete;
+        if (_deletionId is not null) return; // can only delete one at a time
+        _deletionErrorMessage = null;
+        _deletionId = userIdToDelete;
 
         try {
             // Client.DeleteUser is the generated IDeleteUserMutation.
@@ -289,7 +297,7 @@ else {
             IOperationResult<IDeleteUserResult> result = await Client.DeleteUser.ExecuteAsync(userIdToDelete);
 
             if (result.Errors is { Count: > 0 } topLevelErrors) {
-                deletionErrorMessage = $"GraphQL error(s): {string.Join("; ", topLevelErrors.Select(e => e.Message))}";
+                _deletionErrorMessage = $"GraphQL error(s): {string.Join("; ", topLevelErrors.Select(e => e.Message))}";
                 return;
             }
 
@@ -300,11 +308,11 @@ else {
                 // The API returns validation errors as data (error-as-data pattern),
                 // not as HTTP errors. We surface them here.
                 // e.Code is DeleteUserErrorCode enum — compare to old code where it was string.
-                deletionErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
+                _deletionErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
             }
             else if (payload.User is not null) {
                 // Remove the deleted row from the local list without re-fetching.
-                users.RemoveAll(u => u.Id == userIdToDelete);
+                _users.RemoveAll(u => u.Id == userIdToDelete);
             }
             else {
                 // Fallback: server returned HTTP 200, no top-level errors, no payload errors,
@@ -314,41 +322,50 @@ else {
                 // This case exists because GraphQL's type system allows nullable payload fields.
                 // StrawberryShake narrows the type to the generated interface but can't guarantee
                 // non-null at compile time for nullable schema fields.
-                deletionErrorMessage = "Delete did not return a result. The user may not have been deleted.";
+                _deletionErrorMessage = "Delete did not return a result. The user may not have been deleted.";
             }
         }
         catch (Exception ex) {
-            deletionErrorMessage = $"Unexpected error: {ex.Message}";
+            _deletionErrorMessage = $"Unexpected error: {ex.Message}";
         }
         finally {
-            deletionId = null;
+            _deletionId = null;
         }
     }
+
+    private void SetActiveEdit(EditOriginals? model, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
+    {
+        _activeEdit = model;
+        _draftUsername = model?.Username;
+        _draftEmail = model?.Email;
+        _updateErrorMessage = null;
+    }
+
+
+
     // =========================================================================
     // StartEdit — opens the edit panel for a row, pre-filling the fields
     // with the current values from the table so the user sees what's there.
     //
     // TODO: Set editingUserId to user.Id.
     //       Set editUsername and editEmail from the user object passed in.
-    //       Clear updateErrorMessage (stale error from a previous edit attempt).
+    //       Clear _updateErrorMessage (stale error from a previous edit attempt).
     //
     // Blazor tip: no StateHasChanged() needed — assigning to a field and
     // returning from an event handler triggers a re-render automatically.
     // =========================================================================
     private void StartEdit(IGetUsers_Users user)
     {
-        throw new NotImplementedException();
+        EditOriginals currentRow = new EditOriginals(user.Id, user.Username, user.Email);
+        SetActiveEdit(currentRow);
     }
 
     // =========================================================================
     // CancelEdit — closes the edit panel without saving.
-    //
-    // TODO: Set editingUserId to null.
-    //       Clear editUsername, editEmail, updateErrorMessage.
     // =========================================================================
     private void CancelEdit()
     {
-        throw new NotImplementedException();
+        SetActiveEdit(null);
     }
 
     // =========================================================================
@@ -365,7 +382,7 @@ else {
     //              each error: .Code (UpdateUserErrorCode enum), .Message (string)
     //
     // On success:
-    //   - Find the user in the local `users` list by Id and refresh from the
+    //   - Find the user in the local `_users` list by Id and refresh from the
     //     returned payload so the table reflects the new values without a
     //     full re-fetch. Note: IGetUsers_Users is a generated interface — you
     //     can't update it in-place. Replace the list entry instead, or just
@@ -392,12 +409,12 @@ else {
     //       "bootstrap.Modal.getOrCreateInstance(document.getElementById('...)).show()");
     //
     // Better: pass the ElementReference directly —
-    //   await JS.InvokeVoidAsync("bootstrapModalShow", passwordModalRef);
+    //   await JS.InvokeVoidAsync("bootstrapModalShow", _passwordModalRef);
     // and add a tiny JS helper in index.html:
     //   window.bootstrapModalShow = el => bootstrap.Modal.getOrCreateInstance(el).show();
     //   window.bootstrapModalHide = el => bootstrap.Modal.getOrCreateInstance(el).hide();
     //
-    // TODO: Clear editPassword, editPasswordConfirm, passwordErrorMessage.
+    // TODO: Clear _editPassword, _editPasswordConfirm, _passwordErrorMessage.
     //       Call the JS interop to show the modal.
     // =========================================================================
     private async Task OpenPasswordModal()
@@ -409,7 +426,7 @@ else {
     // ClosePasswordModal — hides the Bootstrap modal via JS interop.
     //
     // TODO: Call the JS interop to hide the modal.
-    //       Clear password fields and passwordErrorMessage.
+    //       Clear password fields and _passwordErrorMessage.
     // =========================================================================
     private async Task ClosePasswordModal()
     {
@@ -420,14 +437,14 @@ else {
     // HandlePasswordUpdate — saves a password change only.
     //
     // Client-side validation first:
-    //   - editPassword must not be null/whitespace
-    //   - editPassword must equal editPasswordConfirm (show passwordErrorMessage if not)
+    //   - _editPassword must not be null/whitespace
+    //   - _editPassword must equal _editPasswordConfirm (show _passwordErrorMessage if not)
     //
     // Then calls Client.UpdateUser.ExecuteAsync(
-    //     editingUserId!.Value, username: null, email: null, password: editPassword)
+    //     editingUserId!.Value, username: null, email: null, password: _editPassword)
     //
     // On success: call ClosePasswordModal(). No table update needed (password
-    // isn't displayed). On error: set passwordErrorMessage (stay in the modal).
+    // isn't displayed). On error: set _passwordErrorMessage (stay in the modal).
     //
     // TODO: Implement this method.
     // =========================================================================

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -71,6 +71,22 @@ else {
                            - Otherwise show "Edit" and call StartEdit(user)
                            - Disable while _isUpdating is true (same idea as _deletionId for Delete)
                            Blazor tip: @onclick takes a lambda — "() => StartEdit(user)" *@
+                        @if (_activeEdit?.UserId == user.Id)
+                        {
+                            <button class="btn btn-outline-secondary btn-sm" 
+                                    @onclick="CancelEdit"
+                                    disabled="@_isUpdating">
+                                    ⤴️ Close
+                            </button>
+                        }
+                        else
+                        {
+                            <button class="btn btn-outline-secondary btn-sm"
+                                    @onclick="() => StartEdit(user)"
+                                    disabled="@_isUpdating">
+                                📝 Edit
+                            </button>
+                        }
                     </td>
                     <td>
                         <button class="btn btn-danger btn-sm"

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -1,7 +1,7 @@
 @* =============================================================================
    USERS.RAZOR — User List Page
 
-   This page displays all registered _users fetched via StrawberryShake.
+   This page displays all registered users fetched via StrawberryShake.
 
    What changed from the raw HttpClient version:
      - @inject HttpClient Http  →  @inject IMyTowerClient Client
@@ -133,7 +133,7 @@ else {
                         </tr>
                     }
                 }
-                @*// End if this user is being actively edited*@
+                @* End if this user is being actively edited *@
             } @*End For Each user to be displayed*@
         </tbody>
     </table>
@@ -175,7 +175,7 @@ else {
                 </button>
                 <button class="btn btn-secondary btn-sm ms-1"
                         @onclick="ClosePasswordModal"
-                        @disabled ="@_isUpdatingPassword">
+                        @disabled="@_isUpdatingPassword">
                     Cancel
                 </button>
             </div>
@@ -267,6 +267,7 @@ else {
 
     private async Task RefreshUsers()
     {
+        _errorMessage = null;
         _isLoading = true;
         try {
             // StrawberryShake call: Client.GetUsers is the generated IGetUsersQuery.
@@ -358,6 +359,11 @@ else {
         }
     }
 
+    // [CallerMemberName] fills `caller` with the calling method's name at compile time
+    // (e.g. "StartEdit", "CancelEdit") — no runtime reflection. Currently unused, but
+    // retained as a hook for future tracing/logging: Console.WriteLine($"[SetActiveEdit] called by {caller}");
+    // Other uses: conditional behavior per caller, assertion that only expected callers
+    // can open/close the edit panel, and diagnosing double-open bugs.
     private void SetActiveEdit(EditOriginals? model, [System.Runtime.CompilerServices.CallerMemberName] string caller = "")
     {
         _activeEdit = model;

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -85,7 +85,7 @@ else {
                                     @onclick="() => StartEdit(user)"
                                     disabled="@_isUpdating">
                                 📝 Edit
-                            </button>
+                                </button>
                         }
                     </td>
                     <td>
@@ -102,40 +102,11 @@ else {
                    colspan="6" spans all columns so the panel fills the table width. *@
                 @if (_activeEdit?.UserId == user.Id) {
                     <tr>
-                        <td colspan="6">
-                            <div class="p-3 border rounded bg-light">
-                                <h6>Edit User #@user.Id</h6>
-
-                                @* TODO: Username input field.
-                                   Bind to editUsername with @bind="editUsername".
-                                   Blazor tip: @bind is two-way — it sets the field on change
-                                   AND renders the current value. Equivalent to React's
-                                   value={x} onChange={e => setX(e.target.value)} *@
-
-                                @* TODO: Email input field — same pattern as username,
-                                   bound to editEmail. *@
-
-                                @* TODO: "Change Password…" button.
-                                   Calls OpenPasswordModal() on click.
-                                   Style: btn btn-outline-secondary btn-sm *@
-
-                                @* TODO: Save button — calls HandleUpdate() on click.
-                                   Show "⏳ Saving..." text while _isUpdating is true.
-                                   Disable while _isUpdating is true.
-                                   Style: btn btn-primary btn-sm *@
-
-                                @* TODO: Cancel button — calls CancelEdit() on click.
-                                   Style: btn btn-secondary btn-sm ms-2 *@
-
-                                @* Error message area — only shown when _updateErrorMessage is set *@
-                                @if (_updateErrorMessage is not null) {
-                                    <div class="alert alert-danger mt-2">@_updateErrorMessage</div>
-                                }
-                            </div>
-                        </td>
+                        <td>@user.Id</td>
+                        <td><input type="text" class="form-control form-control-sm" @bind="_draftUsername"/></td>
                     </tr>
-                }
-            }
+                } // End if this user is being actively edited
+            } @*End For Each user to be displayed*@
         </tbody>
     </table>
 

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -28,6 +28,8 @@
 
 @page "/users"
 @inject IMyTowerClient Client
+@* IJSRuntime: needed to call Bootstrap's modal JS API (show/hide) *@
+@inject IJSRuntime JS
 
 <PageTitle>Users — MyTower Admin</PageTitle>
 
@@ -50,6 +52,7 @@ else {
                 <th>Username</th>
                 <th>Email</th>
                 <th>Registered</th>
+                <th>Edit User</th>
                 <th>Remove User</th>
             </tr>
         </thead>
@@ -63,6 +66,13 @@ else {
                     <td>@user.Email</td>
                     <td>@user.CreatedAt.ToString("yyyy-MM-dd")</td>
                     <td>
+                        @* TODO: Render an Edit / Close toggle button.
+                           - If editingUserId == user.Id, show "Close" and call CancelEdit()
+                           - Otherwise show "Edit" and call StartEdit(user)
+                           - Disable while isUpdating is true (same idea as deletionId for Delete)
+                           Blazor tip: @onclick takes a lambda — "() => StartEdit(user)" *@
+                    </td>
+                    <td>
                         <button class="btn btn-danger btn-sm"
                                 @onclick="() => HandleDelete(user.Id)"
                                 @disabled="@(deletionId is not null)"
@@ -71,6 +81,44 @@ else {
                         </button>
                     </td>
                 </tr>
+
+                @* Edit panel — expands below the row when this user is being edited.
+                   colspan="6" spans all columns so the panel fills the table width. *@
+                @if (editingUserId == user.Id) {
+                    <tr>
+                        <td colspan="6">
+                            <div class="p-3 border rounded bg-light">
+                                <h6>Edit User #@user.Id</h6>
+
+                                @* TODO: Username input field.
+                                   Bind to editUsername with @bind="editUsername".
+                                   Blazor tip: @bind is two-way — it sets the field on change
+                                   AND renders the current value. Equivalent to React's
+                                   value={x} onChange={e => setX(e.target.value)} *@
+
+                                @* TODO: Email input field — same pattern as username,
+                                   bound to editEmail. *@
+
+                                @* TODO: "Change Password…" button.
+                                   Calls OpenPasswordModal() on click.
+                                   Style: btn btn-outline-secondary btn-sm *@
+
+                                @* TODO: Save button — calls HandleUpdate() on click.
+                                   Show "⏳ Saving..." text while isUpdating is true.
+                                   Disable while isUpdating is true.
+                                   Style: btn btn-primary btn-sm *@
+
+                                @* TODO: Cancel button — calls CancelEdit() on click.
+                                   Style: btn btn-secondary btn-sm ms-2 *@
+
+                                @* Error message area — only shown when updateErrorMessage is set *@
+                                @if (updateErrorMessage is not null) {
+                                    <div class="alert alert-danger mt-2">@updateErrorMessage</div>
+                                }
+                            </div>
+                        </td>
+                    </tr>
+                }
             }
         </tbody>
     </table>
@@ -79,6 +127,42 @@ else {
         <div class="alert alert-danger">@deletionErrorMessage</div>
     }
 }
+
+@* =============================================================================
+   PASSWORD MODAL
+   A Bootstrap modal rendered as a Razor conditional block.
+   @ref captures the DOM element so JS interop can call bootstrap.Modal.show/hide.
+   ============================================================================= *@
+<div class="modal fade" tabindex="-1" @ref="passwordModalRef">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Change Password</h5>
+                <button type="button" class="btn-close" @onclick="ClosePasswordModal"></button>
+            </div>
+            <div class="modal-body">
+                @* TODO: Password input field — bind to editPassword.
+                   Use type="password" so the browser masks the input.
+                   Blazor tip: <input type="password" class="form-control" @bind="editPassword" /> *@
+
+                @* TODO: Confirm password field — bind to editPasswordConfirm.
+                   We'll validate client-side that both fields match before sending. *@
+
+                @* Error message area for password-specific errors *@
+                @if (passwordErrorMessage is not null) {
+                    <div class="alert alert-danger mt-2">@passwordErrorMessage</div>
+                }
+            </div>
+            <div class="modal-footer">
+                @* TODO: Save Password button — calls HandlePasswordUpdate() on click.
+                   Show "⏳ Saving..." while isUpdatingPassword is true.
+                   Disable while isUpdatingPassword is true. *@
+
+                @* TODO: Cancel button — calls ClosePasswordModal() on click. *@
+            </div>
+        </div>
+    </div>
+</div>
 
 @code {
     // =============================================================================
@@ -102,6 +186,35 @@ else {
     // deletionErrorMessage: holds any delete error to display in the UI
     private int? deletionId;
     private string? deletionErrorMessage;
+
+    // =============================================================================
+    // EDIT PANEL STATE
+    //
+    // editingUserId: which row's edit panel is open (null = none)
+    // editUsername / editEmail: two-way bound to the edit panel's input fields
+    // isUpdating: true while the UpdateUser mutation is in-flight
+    // updateErrorMessage: validation or server errors from the update
+    // =============================================================================
+    private int? editingUserId;
+    private string? editUsername;
+    private string? editEmail;
+    private bool isUpdating;
+    private string? updateErrorMessage;
+
+    // =============================================================================
+    // PASSWORD MODAL STATE
+    //
+    // passwordModalRef: ElementReference captured by @ref on the modal <div>.
+    //   Used by JS interop to call bootstrap.Modal.getOrCreateInstance(el).show/hide.
+    // editPassword / editPasswordConfirm: bound to the two password fields
+    // isUpdatingPassword: true while the password-only UpdateUser call is in-flight
+    // passwordErrorMessage: validation or server errors for the password change
+    // =============================================================================
+    private ElementReference passwordModalRef;
+    private string? editPassword;
+    private string? editPasswordConfirm;
+    private bool isUpdatingPassword;
+    private string? passwordErrorMessage;
 
     // =============================================================================
     // LIFECYCLE: OnInitializedAsync
@@ -210,6 +323,117 @@ else {
         finally {
             deletionId = null;
         }
+    }
+    // =========================================================================
+    // StartEdit — opens the edit panel for a row, pre-filling the fields
+    // with the current values from the table so the user sees what's there.
+    //
+    // TODO: Set editingUserId to user.Id.
+    //       Set editUsername and editEmail from the user object passed in.
+    //       Clear updateErrorMessage (stale error from a previous edit attempt).
+    //
+    // Blazor tip: no StateHasChanged() needed — assigning to a field and
+    // returning from an event handler triggers a re-render automatically.
+    // =========================================================================
+    private void StartEdit(IGetUsers_Users user)
+    {
+        throw new NotImplementedException();
+    }
+
+    // =========================================================================
+    // CancelEdit — closes the edit panel without saving.
+    //
+    // TODO: Set editingUserId to null.
+    //       Clear editUsername, editEmail, updateErrorMessage.
+    // =========================================================================
+    private void CancelEdit()
+    {
+        throw new NotImplementedException();
+    }
+
+    // =========================================================================
+    // HandleUpdate — saves username and/or email changes.
+    //
+    // Calls Client.UpdateUser.ExecuteAsync(id, username, email, password: null).
+    // StrawberryShake signature:
+    //   ExecuteAsync(int id, string? username, string? email, string? password)
+    //   → IOperationResult<IUpdateUserResult>
+    //
+    // Payload path: result.Data!.UpdateUser  (type: IUpdateUser_UpdateUser)
+    //   .User    → IUpdateUser_UpdateUser_User?  (id, username, email)
+    //   .Errors  → IReadOnlyList<IUpdateUser_UpdateUser_Errors>?
+    //              each error: .Code (UpdateUserErrorCode enum), .Message (string)
+    //
+    // On success:
+    //   - Find the user in the local `users` list by Id and refresh from the
+    //     returned payload so the table reflects the new values without a
+    //     full re-fetch. Note: IGetUsers_Users is a generated interface — you
+    //     can't update it in-place. Replace the list entry instead, or just
+    //     reload the full list with a second GetUsers call (simpler for now).
+    //   - Call CancelEdit() to close the panel.
+    //
+    // Error handling follows the same three-branch pattern as HandleDelete:
+    //   1. top-level result.Errors  — transport/auth errors
+    //   2. payload.Errors           — business rule errors (UsernameTaken, etc.)
+    //   3. else                     — unexpected shape fallback
+    //
+    // TODO: Implement this method.
+    // =========================================================================
+    private async Task HandleUpdate()
+    {
+        throw new NotImplementedException();
+    }
+
+    // =========================================================================
+    // OpenPasswordModal — shows the Bootstrap modal via JS interop.
+    //
+    // JS interop syntax:
+    //   await JS.InvokeVoidAsync("eval",
+    //       "bootstrap.Modal.getOrCreateInstance(document.getElementById('...)).show()");
+    //
+    // Better: pass the ElementReference directly —
+    //   await JS.InvokeVoidAsync("bootstrapModalShow", passwordModalRef);
+    // and add a tiny JS helper in index.html:
+    //   window.bootstrapModalShow = el => bootstrap.Modal.getOrCreateInstance(el).show();
+    //   window.bootstrapModalHide = el => bootstrap.Modal.getOrCreateInstance(el).hide();
+    //
+    // TODO: Clear editPassword, editPasswordConfirm, passwordErrorMessage.
+    //       Call the JS interop to show the modal.
+    // =========================================================================
+    private async Task OpenPasswordModal()
+    {
+        throw new NotImplementedException();
+    }
+
+    // =========================================================================
+    // ClosePasswordModal — hides the Bootstrap modal via JS interop.
+    //
+    // TODO: Call the JS interop to hide the modal.
+    //       Clear password fields and passwordErrorMessage.
+    // =========================================================================
+    private async Task ClosePasswordModal()
+    {
+        throw new NotImplementedException();
+    }
+
+    // =========================================================================
+    // HandlePasswordUpdate — saves a password change only.
+    //
+    // Client-side validation first:
+    //   - editPassword must not be null/whitespace
+    //   - editPassword must equal editPasswordConfirm (show passwordErrorMessage if not)
+    //
+    // Then calls Client.UpdateUser.ExecuteAsync(
+    //     editingUserId!.Value, username: null, email: null, password: editPassword)
+    //
+    // On success: call ClosePasswordModal(). No table update needed (password
+    // isn't displayed). On error: set passwordErrorMessage (stay in the modal).
+    //
+    // TODO: Implement this method.
+    // =========================================================================
+    private async Task HandlePasswordUpdate()
+    {
+        throw new NotImplementedException();
     }
 }
 @* End @code *@

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -103,7 +103,27 @@ else {
                 @if (_activeEdit?.UserId == user.Id) {
                     <tr>
                         <td>@user.Id</td>
-                        <td><input type="text" class="form-control form-control-sm" @bind="_draftUsername"/></td>
+                        <td><input type="text" class="form-control form-control-sm" 
+                            @bind="_draftUsername"/></td>
+                        <td><input type="text" class="form-control form-control-sm" 
+                            @bind="_draftEmail" /></td>
+                        <td>
+                            <button class="btn btn-outline-secondary btn-sm" 
+                            @onclick="OpenPasswordModal">🔐 Password... </button>
+                        </td>
+                        <td>
+                            <button class="btn btn-success btn-sm" 
+                                    @onclick="HandleUpdate"
+                                    disabled="@_isUpdating">
+                                @(_isUpdating ? "⌛" : "Save")
+                            </button>
+                            <button class="btn btn-secondary btn-sm ms-1"
+                                         @onclick="CancelEdit"
+                                         @disabled="@_isUpdating">
+                                Cancel
+                        </button>
+                        </td>
+
                     </tr>
                 } // End if this user is being actively edited
             } @*End For Each user to be displayed*@

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -71,28 +71,25 @@ else {
                            - Otherwise show "Edit" and call StartEdit(user)
                            - Disable while _isUpdating is true (same idea as _deletionId for Delete)
                            Blazor tip: @onclick takes a lambda — "() => StartEdit(user)" *@
-                        @if (_activeEdit?.UserId == user.Id)
-                        {
-                            <button class="btn btn-outline-secondary btn-sm" 
+                        @if (_activeEdit?.UserId == user.Id) {
+                            <button class="btn btn-outline-secondary btn-sm"
                                     @onclick="CancelEdit"
-                                    disabled="@_isUpdating">
-                                    ⤴️ Close
+                                    @disabled="@_isUpdating">
+                                ⤴️ Close
                             </button>
                         }
-                        else
-                        {
+                        else {
                             <button class="btn btn-outline-secondary btn-sm"
                                     @onclick="() => StartEdit(user)"
-                                    disabled="@_isUpdating">
+                                    @disabled="@_isUpdating">
                                 📝 Edit
-                                </button>
+                            </button>
                         }
                     </td>
                     <td>
                         <button class="btn btn-danger btn-sm"
                                 @onclick="() => HandleDelete(user.Id)"
-                                @disabled="@(_deletionId is not null)"
-                        >
+                                @disabled="@(_deletionId is not null)">
                             @(_deletionId == user.Id ? "⏳ Deleting..." : "Delete")
                         </button>
                     </td>
@@ -103,29 +100,47 @@ else {
                 @if (_activeEdit?.UserId == user.Id) {
                     <tr>
                         <td>@user.Id</td>
-                        <td><input type="text" class="form-control form-control-sm" 
-                            @bind="_draftUsername"/></td>
-                        <td><input type="text" class="form-control form-control-sm" 
-                            @bind="_draftEmail" /></td>
                         <td>
-                            <button class="btn btn-outline-secondary btn-sm" 
-                            @onclick="OpenPasswordModal">🔐 Password... </button>
+                            <input type="text" class="form-control form-control-sm"
+                                   @bind="_draftUsername" />
                         </td>
                         <td>
-                            <button class="btn btn-success btn-sm" 
+                            <input type="text" class="form-control form-control-sm"
+                                   @bind="_draftEmail" />
+                        </td>
+                        <td>
+                            <button class="btn btn-outline-secondary btn-sm"
+                                    @onclick="OpenPasswordModal">
+                                🔐 Password...
+                            </button>
+                        </td>
+                        <td>
+                            <button class="btn btn-success btn-sm"
                                     @onclick="HandleUpdate"
-                                    disabled="@_isUpdating">
+                                    @disabled="@_isUpdating">
                                 @(_isUpdating ? "⌛" : "Save")
                             </button>
                             <button class="btn btn-secondary btn-sm ms-1"
-                                         @onclick="CancelEdit"
-                                         @disabled="@_isUpdating">
+                                    @onclick="CancelEdit"
+                                    @disabled="@_isUpdating">
                                 Cancel
-                        </button>
+                            </button>
+                        </td>
+                        <td>
+                            😇
                         </td>
 
                     </tr>
-                } // End if this user is being actively edited
+                    @if (_updateErrorMessage is not null)
+                    {
+                        <tr>
+                            <td colspan="6">
+                                <div class="alert alert-danger mb-0">@_updateErrorMessage</div>
+                            </td>
+                        </tr>
+                    }
+                } 
+                @*// End if this user is being actively edited*@
             } @*End For Each user to be displayed*@
         </tbody>
     </table>
@@ -151,10 +166,12 @@ else {
                 @* TODO: Password input field — bind to _editPassword.
                    Use type="password" so the browser masks the input.
                    Blazor tip: <input type="password" class="form-control" @bind="_editPassword" /> *@
-
+                   
+                   New Password <input type="password" class="form-control" @bind="_editPassword" />
                 @* TODO: Confirm password field — bind to _editPasswordConfirm.
                    We'll validate client-side that both fields match before sending. *@
 
+                    Repeat Password <input type="password" class="form-control" @bind="_editPasswordConfirm" />
                 @* Error message area for password-specific errors *@
                 @if (_passwordErrorMessage is not null) {
                     <div class="alert alert-danger mt-2">@_passwordErrorMessage</div>
@@ -199,7 +216,7 @@ else {
     //
     // EditOriginals: Immutable snapshot of the user's values at the moment Edit was clicked
     // _activeEdit: null when no row is open, otherwise points to the original values of the row
-    // _draft*Field*: mutable 
+    // _draft*Field*: mutable
     // =============================================================================
 
     private record EditOriginals(int UserId, string Username, string Email);
@@ -250,6 +267,13 @@ else {
     // =============================================================================
     protected override async Task OnInitializedAsync()
     {
+
+        await RefreshUsers();
+    }
+
+    private async Task RefreshUsers()
+    {
+        _isLoading = true; 
         try {
             // StrawberryShake call: Client.GetUsers is the generated IGetUsersQuery.
             // ExecuteAsync() sends the GetUsers.graphql operation over HTTP, deserializes
@@ -354,10 +378,6 @@ else {
     // StartEdit — opens the edit panel for a row, pre-filling the fields
     // with the current values from the table so the user sees what's there.
     //
-    // TODO: Set editingUserId to user.Id.
-    //       Set editUsername and editEmail from the user object passed in.
-    //       Clear _updateErrorMessage (stale error from a previous edit attempt).
-    //
     // Blazor tip: no StateHasChanged() needed — assigning to a field and
     // returning from an event handler triggers a re-render automatically.
     // =========================================================================
@@ -405,7 +425,48 @@ else {
     // =========================================================================
     private async Task HandleUpdate()
     {
-        throw new NotImplementedException();
+        if (_activeEdit is null) return;
+
+        _updateErrorMessage = null;
+        _isUpdating = true;
+
+        try {
+            IOperationResult<IUpdateUserResult> result =
+                await Client.UpdateUser.ExecuteAsync(
+                    _activeEdit.UserId, _draftUsername, _draftEmail, password: null);
+
+            // var topLevelErrors = result.Errors
+            // if (topLevelErrors is not null && topLevelErrors.Count > 0) {
+            // ... topLevelErrors.Select(e => e.Messge)
+            // }
+            // Idiomatic form — null check, count check, and variable binding in one:
+            if (result.Errors is { Count: > 0} topLevelErrors)
+            {
+                IEnumerable<string> errorList = topLevelErrors.Select(error => error.Message);
+                _updateErrorMessage = $"GraphQL Errors(s): {string.Join("; ", errorList)}";
+                return;
+            }
+
+            // This presumes that Strawberry Shake's payload delivers Data in non-error conditions
+            IUpdateUser_UpdateUser payload = result.Data!.UpdateUser;
+
+            if (payload.Errors is {Count: > 0} validationErrors) {
+                _updateErrorMessage = string.Join(" | ", validationErrors.Select(e => $"{e.Code}: {e.Message}"));
+            }
+            else if (payload.User is not null) {
+                await RefreshUsers();
+                CancelEdit();
+            }
+            else {
+                _updateErrorMessage = "Update did not return a result. The user may not have been saved.";
+            }
+        }
+        catch (Exception ex) {
+            _updateErrorMessage = $"Unexpected error: {ex.Message}";
+        }
+        finally {
+            _isUpdating = false;
+        }
     }
 
     // =========================================================================

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -166,12 +166,14 @@ else {
                 @* TODO: Password input field — bind to _editPassword.
                    Use type="password" so the browser masks the input.
                    Blazor tip: <input type="password" class="form-control" @bind="_editPassword" /> *@
-                   
-                   New Password <input type="password" class="form-control" @bind="_editPassword" />
+                <label class="form-label">New Password</label>
+                <input type="password" class="form-control" @bind="_editPassword" />
+                
                 @* TODO: Confirm password field — bind to _editPasswordConfirm.
                    We'll validate client-side that both fields match before sending. *@
-
-                    Repeat Password <input type="password" class="form-control" @bind="_editPasswordConfirm" />
+                <label class="form-label">Repeat Password</label>
+                <input type="password" class="form-control" @bind="_editPasswordConfirm" />
+                
                 @* Error message area for password-specific errors *@
                 @if (_passwordErrorMessage is not null) {
                     <div class="alert alert-danger mt-2">@_passwordErrorMessage</div>

--- a/MyTowerRegistration.Admin/schema.graphql
+++ b/MyTowerRegistration.Admin/schema.graphql
@@ -29,6 +29,16 @@ type RegisterUserPayload {
   errors: [CreateUserError!]
 }
 
+type UpdateUserError {
+  message: String!
+  code: UpdateUserErrorCode!
+}
+
+type UpdateUserPayload {
+  user: User
+  errors: [UpdateUserError!]
+}
+
 "A registered user"
 type User {
   id: Int!
@@ -40,6 +50,7 @@ type User {
 type UserMutations {
   registerUser(input: RegisterUserInput!): RegisterUserPayload! @cost(weight: "10")
   deleteUser(id: Int!): DeleteUserPayload! @cost(weight: "10")
+  updateUser(input: UpdateUserInput!): UpdateUserPayload! @cost(weight: "10")
 }
 
 type UserQueries {
@@ -51,6 +62,13 @@ input RegisterUserInput {
   username: String!
   email: String!
   password: String!
+}
+
+input UpdateUserInput {
+  id: Int!
+  username: String
+  email: String
+  password: String
 }
 
 enum CreateUserErrorCode {
@@ -67,6 +85,17 @@ enum DeleteUserErrorCode {
   UNAUTHORIZED_ACCESS
   UNAUTHORIZED_DELETION
   UNKNOWN
+}
+
+enum UpdateUserErrorCode {
+  USER_NOT_FOUND
+  UNAUTHORIZED_ACCESS
+  USER_NOT_EDITABLE
+  USERNAME_TAKEN
+  EMAIL_TAKEN
+  INVALID_EMAIL
+  INVALID_PASSWORD
+  INVALID_USERNAME
 }
 
 "The purpose of the `cost` directive is to define a `weight` for GraphQL types, fields, and arguments. Static analysis can use these weights when calculating the overall cost of a query or response."

--- a/MyTowerRegistration.Admin/wwwroot/index.html
+++ b/MyTowerRegistration.Admin/wwwroot/index.html
@@ -29,6 +29,14 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+    <script>
+        window.bootstrapModalShow = (element) => {
+            bootstrap.Modal.getOrCreateInstance(element).show();
+        };
+        window.bootstrapModalHide = (element) => {
+            bootstrap.Modal.getOrCreateInstance(element).hide();
+        }
+    </script>
 </body>
 
 </html>

--- a/MyTowerRegistration.Admin/wwwroot/index.html
+++ b/MyTowerRegistration.Admin/wwwroot/index.html
@@ -29,6 +29,7 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+    <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         window.bootstrapModalShow = (element) => {
             bootstrap.Modal.getOrCreateInstance(element).show();

--- a/MyTowerRegistration.Tests/GlobalUsings.cs
+++ b/MyTowerRegistration.Tests/GlobalUsings.cs
@@ -1,0 +1,4 @@
+﻿// Global type aliases and common usings for the Data project
+global using UserByIdDictionary = System.Collections.Generic.IReadOnlyDictionary<int, MyTowerRegistration.Data.Models.User>;
+global using MyTowerRegistration.Data.Models;
+global using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
## Summary

- Inline edit row expands below each user row with username and email inputs
- Patch semantics: only sends changed fields to avoid false \"already taken\" errors
- Password change modal with client-side confirm validation and JS interop
- Bootstrap JS bundle added to enable modal show/hide via JS interop helpers
- All edit state managed through immutable \`EditOriginals\` snapshot + draft fields
- \`_\` prefix convention applied consistently to all private fields

## Notes

This PR was reviewed in detail during development — each pattern (EditOriginals record, SetActiveEdit with CallerMemberName, three-branch error handling, @disabled vs disabled) was discussed and understood before being written, not vibe-coded.

## Test plan

- [ ] Edit username only — confirm email is not sent (no false \"already taken\" error)
- [ ] Edit email only — same check
- [ ] Edit both fields
- [ ] Save with no changes — confirm no-op handled gracefully
- [ ] Cancel edit — confirm panel closes and fields reset
- [ ] Open password modal — confirm fields clear on open
- [ ] Password mismatch — confirm client-side error shown
- [ ] Password update success — confirm modal closes, edit row stays open
- [ ] Error row appears below edit row on validation failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)