### PR TITLE
Deploy update-user-gui with SPA routing and iOS fixes

### DIFF
--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -486,7 +486,12 @@ else {
         _editPassword = null;
         _editPasswordConfirm = null;
         _passwordErrorMessage = null;
-        await JS.InvokeVoidAsync("bootstrapModalShow", _passwordModalRef);
+        try {
+            await JS.InvokeVoidAsync("bootstrapModalShow", _passwordModalRef);
+        }
+        catch (Exception ex) {
+            _updateErrorMessage = $"Could not open password dialog: {ex.Message}";
+        }
     }
 
     // =========================================================================
@@ -497,7 +502,12 @@ else {
         _editPassword = null;
         _editPasswordConfirm = null;
         _passwordErrorMessage = null;
-        await JS.InvokeVoidAsync("bootstrapModalHide", _passwordModalRef);
+        try {
+            await JS.InvokeVoidAsync("bootstrapModalHide", _passwordModalRef);
+        }
+        catch (Exception ex) {
+            _passwordErrorMessage = $"Could not close dialog: {ex.Message}";
+        }
     }
 
     // =========================================================================

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -30,6 +30,7 @@
 @inject IMyTowerClient Client
 @* IJSRuntime: needed to call Bootstrap's modal JS API (show/hide) *@
 @inject IJSRuntime JS
+@inject ILogger<Users> Logger
 
 <PageTitle>Users — MyTower Admin</PageTitle>
 
@@ -490,7 +491,9 @@ else {
             await JS.InvokeVoidAsync("bootstrapModalShow", _passwordModalRef);
         }
         catch (Exception ex) {
-            _updateErrorMessage = $"Could not open password dialog: {ex.Message}";
+            Logger.LogError(ex, "bootstrapModalShow failed");
+            const string msg = "Could not open the password dialog. Please try again.";
+            _updateErrorMessage = _updateErrorMessage is null ? msg : $"{_updateErrorMessage} | {msg}";
         }
     }
 
@@ -499,14 +502,15 @@ else {
     // =========================================================================
     private async Task ClosePasswordModal()
     {
-        _editPassword = null;
-        _editPasswordConfirm = null;
-        _passwordErrorMessage = null;
         try {
             await JS.InvokeVoidAsync("bootstrapModalHide", _passwordModalRef);
+            _editPassword = null;
+            _editPasswordConfirm = null;
+            _passwordErrorMessage = null;
         }
         catch (Exception ex) {
-            _passwordErrorMessage = $"Could not close dialog: {ex.Message}";
+            Logger.LogError(ex, "bootstrapModalHide failed");
+            _passwordErrorMessage = "Could not close the dialog — click ✕ to retry or refresh the page.";
         }
     }
 
@@ -555,6 +559,10 @@ else {
 
             if (payload.User is not null) {
                 await ClosePasswordModal();
+                if (_passwordErrorMessage is not null) {
+                    _passwordErrorMessage = "Password saved. The dialog could not close automatically — " +
+                                            "click ✕ to retry or refresh the page.";
+                }
             }
             else if (payload.Errors is { Count: > 0 } validationErrors) {
                 IEnumerable<string> errorMessages = validationErrors.Select(error => $"{error.Code} : {error.Message}");

--- a/MyTowerRegistration.Admin/Pages/Users.razor
+++ b/MyTowerRegistration.Admin/Pages/Users.razor
@@ -69,14 +69,14 @@ else {
                         @if (_activeEdit?.UserId == user.Id) {
                             <button class="btn btn-outline-secondary btn-sm"
                                     @onclick="CancelEdit"
-                                    @disabled="@_isUpdating">
+                                    disabled="@_isUpdating">
                                 ⤴️ Close
                             </button>
                         }
                         else {
                             <button class="btn btn-outline-secondary btn-sm"
                                     @onclick="() => StartEdit(user)"
-                                    @disabled="@_isUpdating">
+                                    disabled="@_isUpdating">
                                 📝 Edit
                             </button>
                         }
@@ -84,7 +84,7 @@ else {
                     <td>
                         <button class="btn btn-danger btn-sm"
                                 @onclick="() => HandleDelete(user.Id)"
-                                @disabled="@(_deletionId is not null)">
+                                disabled="@(_deletionId is not null)">
                             @(_deletionId == user.Id ? "⏳ Deleting..." : "Delete")
                         </button>
                     </td>
@@ -112,12 +112,12 @@ else {
                         <td>
                             <button class="btn btn-success btn-sm"
                                     @onclick="HandleUpdate"
-                                    @disabled="@_isUpdating">
+                                    disabled="@_isUpdating">
                                 @(_isUpdating ? "⌛" : "Save")
                             </button>
                             <button class="btn btn-secondary btn-sm ms-1"
                                     @onclick="CancelEdit"
-                                    @disabled="@_isUpdating">
+                                    disabled="@_isUpdating">
                                 Cancel
                             </button>
                         </td>
@@ -170,12 +170,12 @@ else {
             <div class="modal-footer">
                 <button class="btn btn-success btn-sm"
                         @onclick="HandlePasswordUpdate"
-                        @disabled="@_isUpdatingPassword">
+                        disabled="@_isUpdatingPassword">
                     @(_isUpdatingPassword ? "📝 Saving..." : "Save")
                 </button>
                 <button class="btn btn-secondary btn-sm ms-1"
                         @onclick="ClosePasswordModal"
-                        @disabled="@_isUpdatingPassword">
+                        disabled="@_isUpdatingPassword">
                     Cancel
                 </button>
             </div>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -348,7 +348,7 @@ echo "CloudFront cache invalidated."
 CF_CONFIG_RESPONSE=$(aws cloudfront get-distribution-config --id "${CF_ID}")
 CF_ETAG=$(echo "${CF_CONFIG_RESPONSE}" | jq -r '.ETag')
 DIST_CONFIG=$(echo "${CF_CONFIG_RESPONSE}" | jq '.DistributionConfig')
-HAS_403=$(echo "${DIST_CONFIG}" | jq '[.CustomErrorResponses.Items[] | select(.ErrorCode == 403)] | length')
+HAS_403=$(echo "${DIST_CONFIG}" | jq '[(.CustomErrorResponses.Items // [])[] | select(.ErrorCode == 403)] | length')
 if [ "${HAS_403}" -eq 0 ]; then
     PATCHED_CONFIG=$(echo "${DIST_CONFIG}" | jq '
         .CustomErrorResponses.Quantity += 1 |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -341,6 +341,32 @@ aws cloudfront create-invalidation \
     --paths "/*" > /dev/null
 echo "CloudFront cache invalidated."
 
+# Ensure both 403 and 404 are mapped to /index.html for SPA routing.
+# When the bucket is private (OAC), S3 returns 403 for missing paths —
+# not 404. Without a 403 rule, navigating directly to any Blazor route
+# (e.g. /users) returns the raw S3 "Access Denied" XML instead of the app.
+CF_CONFIG_RESPONSE=$(aws cloudfront get-distribution-config --id "${CF_ID}")
+CF_ETAG=$(echo "${CF_CONFIG_RESPONSE}" | jq -r '.ETag')
+DIST_CONFIG=$(echo "${CF_CONFIG_RESPONSE}" | jq '.DistributionConfig')
+HAS_403=$(echo "${DIST_CONFIG}" | jq '[.CustomErrorResponses.Items[] | select(.ErrorCode == 403)] | length')
+if [ "${HAS_403}" -eq 0 ]; then
+    PATCHED_CONFIG=$(echo "${DIST_CONFIG}" | jq '
+        .CustomErrorResponses.Quantity += 1 |
+        .CustomErrorResponses.Items += [{
+            "ErrorCode": 403,
+            "ResponseCode": "200",
+            "ResponsePagePath": "/index.html",
+            "ErrorCachingMinTTL": 0
+        }]')
+    aws cloudfront update-distribution \
+        --id "${CF_ID}" \
+        --distribution-config "${PATCHED_CONFIG}" \
+        --if-match "${CF_ETAG}" > /dev/null
+    echo "CloudFront: added 403 → /index.html SPA routing rule."
+else
+    echo "CloudFront: 403 SPA routing rule already present."
+fi
+
 echo "OK"
 
 # =============================================================================

--- a/scripts/setup-infra.sh
+++ b/scripts/setup-infra.sh
@@ -553,10 +553,11 @@ echo "OK"
 # There is no server — the browser downloads everything once and runs the
 # app locally in WASM. We host on S3 and serve via CloudFront (AWS CDN).
 #
-# SPA routing: if a user bookmarks /admin/users, their browser requests that
-# path from S3. S3 returns 404 — no file at that path exists. We configure
-# a CloudFront custom error response: 404 → /index.html (HTTP 200). Blazor's
-# client-side Router picks up the URL and navigates correctly.
+# SPA routing: if a user navigates directly to /users or any other Blazor
+# route, CloudFront asks S3 for that path — no file exists there. When the
+# bucket is private (OAC), S3 returns 403 Access Denied (not 404) for missing
+# objects. We configure custom error responses for BOTH 403 and 404 → /index.html
+# (HTTP 200). Blazor's client-side Router picks up the URL and navigates correctly.
 #
 # S3 public access is blocked — CloudFront fetches objects using an Origin
 # Access Control (OAC), which signs requests with SigV4. The bucket is never
@@ -645,13 +646,21 @@ if [ -z "${EXISTING_CF_ID}" ] || [ "${EXISTING_CF_ID}" = "None" ]; then
         }
     },
     "CustomErrorResponses": {
-        "Quantity": 1,
-        "Items": [{
-            "ErrorCode": 404,
-            "ResponseCode": "200",
-            "ResponsePagePath": "/index.html",
-            "ErrorCachingMinTTL": 0
-        }]
+        "Quantity": 2,
+        "Items": [
+            {
+                "ErrorCode": 404,
+                "ResponseCode": "200",
+                "ResponsePagePath": "/index.html",
+                "ErrorCachingMinTTL": 0
+            },
+            {
+                "ErrorCode": 403,
+                "ResponseCode": "200",
+                "ResponsePagePath": "/index.html",
+                "ErrorCachingMinTTL": 0
+            }
+        ]
     },
     "Enabled": true,
     "PriceClass": "PriceClass_100",


### PR DESCRIPTION
## Summary

- Deploys PR #28 (update-user-gui feature) to production
- Fixes direct-URL navigation returning S3 Access Denied XML on all SPA routes
- Fixes Blazor crash banner on iOS/Safari when using the Edit User password modal

## Changes

**CloudFront SPA routing (`scripts/deploy.sh`, `scripts/setup-infra.sh`)**
S3 with OAC returns 403 (not 404) for missing paths in a private bucket. CloudFront only had a 404 → `/index.html` custom error response, so direct navigation to any Blazor route (e.g. `/users`) returned raw `<AccessDenied>` XML. Added a matching 403 rule. `deploy.sh` patches the live distribution idempotently on each run; `setup-infra.sh` updated for future fresh environments.

**iOS Safari crash (`Users.razor`)**
Two issues:
1. `@disabled="@expr"` — Blazor leaks the literal `@disabled` string to WebKit's `setAttribute`, which rejects `@` as an invalid attribute name character. Chrome/Firefox silently tolerate it; WebKit correctly throws. Changed to `disabled="@expr"` throughout.
2. `OpenPasswordModal` and `ClosePasswordModal` called `JS.InvokeVoidAsync` without try/catch. When invoked directly as button event handlers, any JS interop exception propagated as an unhandled component exception → crash banner. Wrapped both in try/catch.

## Test plan

- [ ] Navigate directly to `https://admin.mytower.dev/users` — should load the users page, not XML
- [ ] Open Edit panel, click 🔐 Password, enter and save a new password on iOS Safari — no crash banner
- [ ] Verify disabled button states work correctly during in-flight operations (Edit, Delete, Save)
- [ ] Verify normal desktop browser behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)